### PR TITLE
✨ Feat: 검색 결과에 나온 모든 책들의 키워드로 필터링 검색 기능 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,93 +1,93 @@
-import React, { useEffect } from 'react';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import React, { useEffect } from "react";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 // PAGES
-import Home from './pages/Home';
-import Main from './pages/LoginHome';
-import Feed from './pages/Feed';
-import MyFeed from './pages/MyFeed';
-import Search from './pages/Search';
-import Mypage from './pages/Mypage';
-import BookDetail from './pages/BookDetail';
-import Login from './pages/Login';
-import Join from './pages/Join';
-import Signup2 from './pages/Signup2';
-import Signup3 from './pages/Signup3';
-import FindUserInfo from './pages/FindUserInfo';
-import Registration from './pages/Registration';
-import BookList from './pages/BookList';
-import SmallCategory from './pages/SmallCategory';
-import Edit from './pages/Edit';
-import UserInfo from './pages/UserInfo';
+import Home from "./pages/Home";
+import Main from "./pages/LoginHome";
+import Feed from "./pages/Feed";
+import MyFeed from "./pages/MyFeed";
+import Search from "./pages/Search";
+import Mypage from "./pages/Mypage";
+import BookDetail from "./pages/BookDetail";
+import Login from "./pages/Login";
+import Join from "./pages/Join";
+import Signup2 from "./pages/Signup2";
+import Signup3 from "./pages/Signup3";
+import FindUserInfo from "./pages/FindUserInfo";
+import Registration from "./pages/Registration";
+import BookList from "./pages/BookList";
+import SmallCategory from "./pages/SmallCategory";
+import Edit from "./pages/Edit";
+import UserInfo from "./pages/UserInfo";
 
 // 처방전 관련 페이지들
-import Counseling from './pages/Counseling';
+import Counseling from "./pages/Counseling";
 
 // STYLE
-import GlobalStyles from './styles/GlobalStyles';
-import './App.css';
-import ScrollTop from './components/ScrollTop';
-import LoginLayout from './components/LoginLayout';
-import LoginFindResult from './pages/IdFindResult';
-import PasswordFind from './pages/PasswordFind';
-import PasswordFindResult from './pages/PasswordFindResult';
-import IdFind from './pages/IdFind';
-import LoginContextProvider from './contexts/LoginContextProvider';
-import SearchResult from './pages/SearchResult';
+import GlobalStyles from "./styles/GlobalStyles";
+import "./App.css";
+import ScrollTop from "./components/ScrollTop";
+import LoginLayout from "./components/LoginLayout";
+import LoginFindResult from "./pages/IdFindResult";
+import PasswordFind from "./pages/PasswordFind";
+import PasswordFindResult from "./pages/PasswordFindResult";
+import IdFind from "./pages/IdFind";
+import LoginContextProvider from "./contexts/LoginContextProvider";
+import SearchResult from "./pages/SearchResult";
 
 function App() {
-	// 브라우저 새로고침 스크롤 이벤트
-	useEffect(() => {
-		window.onbeforeunload = function pushRefresh() {
-			window.scrollTo(0, 0);
-		};
-	}, []);
+  // 브라우저 새로고침 스크롤 이벤트
+  useEffect(() => {
+    window.onbeforeunload = function pushRefresh() {
+      window.scrollTo(0, 0);
+    };
+  }, []);
 
-	https: return (
-		<BrowserRouter>
-			<LoginContextProvider>
-				<div className="App">
-					<GlobalStyles />
-					<ScrollTop />
-					<Routes>
-						<Route path="/" element={<Home />} />
-						<Route path="/logout" element={<Home />} />
-						<Route path="/main" element={<Main />} />
-						<Route path="/feed" element={<Feed />} />
-						<Route path="/search" element={<Search />} />
-						<Route path="/search/result/:title" element={<SearchResult />} />
-						<Route path="/mypage" element={<Mypage />} />
-						<Route path="/myfeed" element={<MyFeed />} />
-						<Route path="/edit" element={<Edit />} />
-						<Route path="/edit/:page" element={<UserInfo />} />
+  https: return (
+    <BrowserRouter>
+      <LoginContextProvider>
+        <div className="App">
+          <GlobalStyles />
+          <ScrollTop />
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/logout" element={<Home />} />
+            <Route path="/main" element={<Main />} />
+            <Route path="/feed" element={<Feed />} />
+            <Route path="/search" element={<Search />} />
+            <Route path="/search/result/:title" element={<SearchResult />} />
+            <Route path="/mypage" element={<Mypage />} />
+            <Route path="/myfeed" element={<MyFeed />} />
+            <Route path="/edit" element={<Edit />} />
+            <Route path="/edit/:page" element={<UserInfo />} />
 
-						<Route path="/counseling" element={<Counseling />} />
+            <Route path="/counseling" element={<Counseling />} />
 
-						<Route element={<LoginLayout />}>
-							<Route path="/id-find" element={<IdFind />} />
-							<Route path="/id-find-result" element={<LoginFindResult />} />
-							<Route path="/password-find" element={<PasswordFind />} />
-							<Route
-								path="/password-find-result"
-								element={<PasswordFindResult />}
-							/>
-						</Route>
-						<Route path="/test" element={<Registration />} />
-						<Route path="/login" element={<Login />} />
-						<Route path="/signup" element={<Join />} />
-						<Route path="/signup/1" element={<Signup2 />} />
-						<Route path="/signup/2" element={<Signup3 />} />
-						{/* <Route path="/find/user/info/:page" element={<FindUserInfo />} /> */}
-						<Route path="/test" element={<Registration />} />
+            <Route element={<LoginLayout />}>
+              <Route path="/id-find" element={<IdFind />} />
+              <Route path="/id-find-result" element={<LoginFindResult />} />
+              <Route path="/password-find" element={<PasswordFind />} />
+              <Route
+                path="/password-find-result"
+                element={<PasswordFindResult />}
+              />
+            </Route>
+            <Route path="/test" element={<Registration />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/signup" element={<Join />} />
+            <Route path="/signup/1" element={<Signup2 />} />
+            <Route path="/signup/2" element={<Signup3 />} />
+            {/* <Route path="/find/user/info/:page" element={<FindUserInfo />} /> */}
+            <Route path="/test" element={<Registration />} />
 
-						<Route path="/book-detail" element={<BookDetail />} />
-						<Route path="/book/list/:title" element={<BookList />} />
-						<Route path="/book/:title/:category" element={<SmallCategory />} />
-					</Routes>
-				</div>
-			</LoginContextProvider>
-		</BrowserRouter>
-	);
+            <Route path="/book-detail" element={<BookDetail />} />
+            <Route path="/book/list/:title" element={<BookList />} />
+            <Route path="/book/:title/:category" element={<SmallCategory />} />
+          </Routes>
+        </div>
+      </LoginContextProvider>
+    </BrowserRouter>
+  );
 }
 
 export default App;

--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -2,7 +2,13 @@ import React from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 
-const Pagination = ({ booksPerPage, totalBooks, paginate, bookTitle }) => {
+const Pagination = ({
+  booksPerPage,
+  totalBooks,
+  paginate,
+  bookTitle,
+  currentPage,
+}) => {
   const pageNumbers = [];
   // console.log(totalBooks, booksPerPage);
   for (let i = 1; i <= Math.ceil(totalBooks / booksPerPage); i++) {
@@ -15,27 +21,17 @@ const Pagination = ({ booksPerPage, totalBooks, paginate, bookTitle }) => {
       <PaginationContainer className="pagination">
         {pageNumbers.map((number) => {
           return (
-            <li
+            <PageItem
               key={number}
               className="page-item"
-              style={{
-                textAlign: "center",
-                marginTop: "30px",
-                marginBottom: "60px",
-                padding: "4px",
+              isCurrent={number === currentPage}
+              onClick={() => {
+                window.scrollTo(0, 0);
+                paginate(number);
               }}
             >
-              {/* <a onClick={()=>paginate(number)} href={bookTitle} className="page-link"> */}
-              <Link
-                onClick={() => {
-                  window.scrollTo(0, 0);
-                  paginate(number);
-                }}
-              >
-                {number}
-              </Link>
-              {/* </a> */}
-            </li>
+              {number}
+            </PageItem>
           );
         })}
       </PaginationContainer>
@@ -48,4 +44,23 @@ export default Pagination;
 const PaginationContainer = styled.ul`
   display: flex;
   justify-content: center;
+`;
+
+const PageItem = styled.li`
+  text-align: center;
+  margin-top: 30px;
+  margin-bottom: 60px;
+  padding: 4px;
+  color: ${(props) =>
+    props.isCurrent
+      ? "#00A2BC"
+    : "black"}; // 현재 페이지일 때 빨간색, 아니면 검은색
+  font-weight: ${(props)=> props.isCurrent ? "bold" : "normal"};
+
+  &:hover {
+    cursor: pointer;
+    background-color: #d5d5d5;
+    border-radius: 50%;
+    text-decoration: underline;
+  }
 `;

--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -4,10 +4,10 @@ import styled from "styled-components";
 
 const Pagination = ({ booksPerPage, totalBooks, paginate, bookTitle }) => {
   const pageNumbers = [];
-  console.log(totalBooks, booksPerPage);
+  // console.log(totalBooks, booksPerPage);
   for (let i = 1; i <= Math.ceil(totalBooks / booksPerPage); i++) {
     pageNumbers.push(i);
-    console.log(pageNumbers);
+    // console.log(pageNumbers);
   }
 
   return (

--- a/src/components/Pill.jsx
+++ b/src/components/Pill.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const Pill = ({ text, onClick }) => {
+  return (
+    <KeywordPill className="user-pill" onClick={onClick}>
+      {text} &times;
+    </KeywordPill>
+  );
+}
+
+export default Pill
+
+const KeywordPill = styled.span`
+  height: 30px;
+  display: flex;
+  align-items: center;
+  /* gap: 5px; */
+  margin-right: 5px;
+  color: black;
+  background-color: #c8edf2;
+  padding: 5px 10px;
+  border-radius: 16px;
+  font-size: 16px;
+  cursor: pointer;
+`;

--- a/src/components/SearchBox.jsx
+++ b/src/components/SearchBox.jsx
@@ -66,7 +66,6 @@ const SearchBox = ({
                     text={keyword}
                     onClick={() => {
                       handleRemoveKeyword(keyword);
-                      console.log("123");
                     }}
                   />
                 );

--- a/src/components/SearchBox.jsx
+++ b/src/components/SearchBox.jsx
@@ -112,17 +112,17 @@ const SearchInputWrap = styled.div`
   width: 100%;
   height: 60px;
   box-shadow: 0px 2px 4px #00000033;
-  padding: 10px 0px 10px 1rem;
+  padding: 10px 0px 10px 16px;
   border-radius: 5px;
   border: 1px solid #b0b0b0;
   display: flex;
-  align-items: center;
+  /* align-items: center; */
   font-size: 20px;
   /* margin-bottom: 40px; */
 `;
 
 const SelectMenu = styled.select`
-  width: 140px;
+  min-width: 140px;
   font-size: 20px;
   border: none;
   /* padding-left: 10px; */

--- a/src/components/SearchBox.jsx
+++ b/src/components/SearchBox.jsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react'
-import SearchResultListModal from './SearchResultListModal';
+import React, { useState } from "react";
+import SearchResultListModal from "./SearchResultListModal";
 
 // style
 import "../styles/SearchStyles.css";
-import styled from 'styled-components';
+import styled from "styled-components";
 
 const SearchBox = ({
   input,
@@ -15,8 +15,6 @@ const SearchBox = ({
   setIsShow,
   searchData,
 }) => {
-
-  
   return (
     <section
       className="search-wrapper"
@@ -37,7 +35,10 @@ const SearchBox = ({
               /> */}
           <SelectMenu
             value={searchType}
-            onChange={(e) => setSearchType(e.target.value)}
+            onChange={(e) => {
+              setSearchType(e.target.value);
+              setInput("");
+            }}
             name=""
             id=""
             // className="search-select"

--- a/src/components/SearchBox.jsx
+++ b/src/components/SearchBox.jsx
@@ -4,6 +4,7 @@ import SearchResultListModal from "./SearchResultListModal";
 // style
 import "../styles/SearchStyles.css";
 import styled from "styled-components";
+import Pill from "./Pill";
 
 const SearchBox = ({
   input,
@@ -14,6 +15,11 @@ const SearchBox = ({
   isShow,
   setIsShow,
   searchData,
+  handleSelectKeyword,
+  selectedKeyword,
+  selectedKeywordSet,
+  handleRemoveKeyword,
+  inputRef,
 }) => {
   return (
     <section
@@ -34,6 +40,7 @@ const SearchBox = ({
                 name="search-button"
               /> */}
           <SelectMenu
+            // defaultValue="title"
             value={searchType}
             onChange={(e) => {
               setSearchType(e.target.value);
@@ -43,7 +50,8 @@ const SearchBox = ({
             id=""
             // className="search-select"
           >
-            <option value="title" selected>
+            {/* <option value="title" selected> */}
+            <option value="title">
               책제목
             </option>
             <option value="author">작가</option>
@@ -51,7 +59,20 @@ const SearchBox = ({
           </SelectMenu>
           {searchType === "keyword" ? (
             <>
+              {selectedKeyword.map((keyword, index) => {
+                return (
+                  <Pill
+                    key={index}
+                    text={keyword}
+                    onClick={() => {
+                      handleRemoveKeyword(keyword);
+                      console.log("123");
+                    }}
+                  />
+                );
+              })}
               <SearchInput
+                ref={inputRef}
                 type="text"
                 placeholder="검색어를 입력하세요"
                 // className="search-input"
@@ -97,7 +118,8 @@ const SearchBox = ({
         // />
         <SearchResultListModal
           book={searchData}
-          addInput={setInput}
+          addInput={handleSelectKeyword}
+          selectedKeywordSet={selectedKeywordSet}
           onClick={(e) => {
             e.stopPropagation();
           }}
@@ -117,7 +139,7 @@ const SearchInputWrap = styled.div`
   border-radius: 5px;
   border: 1px solid #b0b0b0;
   display: flex;
-  /* align-items: center; */
+  align-items: center;
   font-size: 20px;
   /* margin-bottom: 40px; */
 `;
@@ -126,7 +148,8 @@ const SelectMenu = styled.select`
   min-width: 140px;
   font-size: 20px;
   border: none;
-  /* padding-left: 10px; */
+  /* border-right: 1px solid #c0c0c0; */
+  /* padding-r: 10px; */
   text-align: center;
   &:focus {
     outline: none;
@@ -135,11 +158,12 @@ const SelectMenu = styled.select`
 
 const SearchInput = styled.input`
   border: none;
-  border-left: 1px solid #c0c0c0;
-  margin-left: 1rem;
+  /* border-left: 1px solid #c0c0c0; */
+  /* margin-left: 1rem; */
   padding-left: 1rem;
   font-size: 20px;
-  width: 100%;
+  /* width: 100%; */
+  flex: 1;
   &:focus {
     outline: none;
   }

--- a/src/components/SearchBox.jsx
+++ b/src/components/SearchBox.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import SearchResultListModal from "./SearchResultListModal";
 
 // style

--- a/src/components/SearchResultListModal.jsx
+++ b/src/components/SearchResultListModal.jsx
@@ -1,8 +1,15 @@
-import React from 'react'
+import React from "react";
 import "../styles/SearchResultList.css";
-import { Link } from 'react-router-dom';
+import { Link } from "react-router-dom";
+import styled from "styled-components";
 
-const SearchResultListModal = ({ book, type, updateBook, addInput }) => {
+const SearchResultListModal = ({
+  book,
+  type,
+  updateBook,
+  addInput,
+  selectedKeywordSet,
+}) => {
   let listType = ["myBook"].includes(type) ? type : "search";
 
   return (
@@ -41,13 +48,22 @@ const SearchResultListModal = ({ book, type, updateBook, addInput }) => {
 
           // 키워드 UI
           if (keyword !== undefined) {
-            return (
-              <p
+            
+            return !selectedKeywordSet.has(keyword) ? (
+              <KeywordItem
                 style={{ fontSize: "20px", marginBottom: "10px" }}
-                onClick={()=>addInput(`#${keyword}`)}
+                onClick={() => addInput(keyword)}
               >
                 {keyword}
-              </p>
+              </KeywordItem>
+            ) : (
+              // <p
+              //   style={{ fontSize: "20px", marginBottom: "10px"}}
+              //   onClick={() => addInput(keyword)}
+              // >
+              //   {keyword}
+              // </p>
+              <></>
             );
           }
           return null;
@@ -55,10 +71,19 @@ const SearchResultListModal = ({ book, type, updateBook, addInput }) => {
       </div>
     </>
   );
-}
+};
 
 SearchResultListModal.defaultProps = {
   type: "search",
 };
 
-export default SearchResultListModal
+export default SearchResultListModal;
+
+const KeywordItem = styled.p`
+  font-size: 20px;
+  margin-bottom: 10px;
+  &:hover {
+    background-color: #d6d6d6;
+    border-radius: 4px;
+  }
+`;

--- a/src/components/SearchResultListModal.jsx
+++ b/src/components/SearchResultListModal.jsx
@@ -16,7 +16,7 @@ const SearchResultListModal = ({
     <>
       <div className={`${listType}-modal-container`}>
         {book.map((item) => {
-          console.log(item);
+          // console.log(item);
           // 작가에서 누구 지음 이걸 빼주도록 하기 -> 작가 이름을 어떻게 필터링 처리를 할까?
 
           let title = item && item.title;

--- a/src/components/SearchResultListModal.jsx
+++ b/src/components/SearchResultListModal.jsx
@@ -5,10 +5,6 @@ import { Link } from 'react-router-dom';
 const SearchResultListModal = ({ book, type, updateBook, addInput }) => {
   let listType = ["myBook"].includes(type) ? type : "search";
 
-  const updateBookTitle = (pickTitle) => {
-    updateBook(pickTitle);
-  };
-
   return (
     <>
       <div className={`${listType}-modal-container`}>
@@ -20,12 +16,13 @@ const SearchResultListModal = ({ book, type, updateBook, addInput }) => {
           let author = item && item.author;
           let thumbnail = item && item.imageUrl;
           let keyword = item && item.name;
+          let isbn = item && item.isbn;
 
           // 책 제목 && 작가 UI
           if (title !== undefined) {
             return (
-              <ul key={item.id} className={`${listType}-result-container`}>
-                <Link to={`/book-detial/${title}`}>
+              <ul key={item.isbn} className={`${listType}-result-container`}>
+                <Link to={`/book-detial/${isbn}`}>
                   <li className={`${listType}-result-list`}>
                     <img src={thumbnail} alt="" />
                     <div className={`${listType}-result-item`}>
@@ -53,6 +50,7 @@ const SearchResultListModal = ({ book, type, updateBook, addInput }) => {
               </p>
             );
           }
+          return null;
         })}
       </div>
     </>

--- a/src/components/TodayPrescription.jsx
+++ b/src/components/TodayPrescription.jsx
@@ -1,9 +1,0 @@
-import React from 'react'
-
-function TodayPrescription() {
-  return (
-    <div>TodayPrescription</div>
-  )
-}
-
-export default TodayPrescription

--- a/src/pages/SearchResult.jsx
+++ b/src/pages/SearchResult.jsx
@@ -7,6 +7,7 @@ import starIcon from "../assets/icons8-별-30 (1).png";
 import api from "./../services/api";
 import Pagination from "../components/Pagination";
 import SearchBox from "../components/SearchBox";
+import Pill from "../components/Pill";
 
 const SearchResult = () => {
   const navigate = useNavigate();
@@ -15,6 +16,7 @@ const SearchResult = () => {
   const [books, setBooks] = useState([]); // 책 정보
   const [currentPage, setCurrentPage] = useState(1); // 현재 페이지
   const [booksPerPage, setBooksPerPage] = useState(10); // 페이지당 책 수
+
   const [loading, setLoading] = useState(false); // 로딩 상태
 
   const [input, setInput] = useState(""); // 검색 데이터
@@ -26,7 +28,10 @@ const SearchResult = () => {
   const [selectedKeywords, setSelectedKeywords] = useState([]);
   const [selectedKeywordSet, setSelectedKeywordSet] = useState(new Set());
 
-  const [totalBooksOfKeywords, setTotalBooksOfKeywords] = useState([]);
+
+  const [searchedSelectedKeywords, setSearchedSelectedKeywords] = useState([]);
+  
+
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -63,23 +68,45 @@ const SearchResult = () => {
   const searchBook = (evt) => {
     if (evt.key === "Enter") {
       fetchBooks(input);
-      if (input.length > 0 && selectedKeywords.length === 0) navigate(`/search/result/${input}`);
-      if (selectedKeywords.length > 0) navigate(`/search/result/${selectedKeywords.join(' ')} ${input}`);
-      if(input.length === 0 && searchType !== "keyword") alert("검색 키워드가 없습니다!")
-      if (searchType === "keyword" && selectedKeywords.length === 0) alert("키워드를 선택하여 검색해주세요!")
-        setIsShow(false);
+      if (input.length > 0 && selectedKeywords.length === 0)
+        navigate(`/search/result/${input}`);
+      if (selectedKeywords.length > 0)
+        navigate(`/search/result/${selectedKeywords.join(" ")} ${input}`);
+      if (input.length === 0 && searchType !== "keyword")
+        alert("검색 키워드가 없습니다!");
+      if (searchType === "keyword" && selectedKeywords.length === 0)
+        alert("키워드를 선택하여 검색해주세요!");
+      setIsShow(false);
     }
   };
 
   // 키워드로 어떻게 담지?
 
- 
+  // const { searchedSelectedKeywords,removeKeyword } = useSearchedSelectedKeywords();
+  // console.log(searchedSelectedKeywords)
 
   // 현재 책들 정보
+  // const filteredBooks = books.filter(
+  //   (book) =>
+  //     book.bookKeywordList.some((keyword) =>
+  //       searchedSelectedKeywords.includes(keyword.name)
+  //     ) || searchedSelectedKeywords.includes(book.middleCategoryName)
+  // );
+  const filteredBooks = books.filter((book) =>
+    searchedSelectedKeywords.every(
+      (keyword) =>
+        book.bookKeywordList.some(
+          (bookKeyword) => bookKeyword.name === keyword
+        ) || keyword === book.middleCategoryName
+    )
+  );
+
+  console.log("Filtered Books: ", filteredBooks);
+
   const indexOfLastBook = currentPage * booksPerPage;
   const indexOfFirstBook = indexOfLastBook - booksPerPage;
-  // console.log(indexOfFirstBook, indexOfLastBook);
-  const currentBooks = books.slice(indexOfFirstBook, indexOfLastBook);
+  // const currentBooks = books.slice(indexOfFirstBook, indexOfLastBook);
+  const currentBooks = filteredBooks.slice(indexOfFirstBook, indexOfLastBook);
 
   // 페이지 변경
   const paginate = (pageNumber) => setCurrentPage(pageNumber);
@@ -92,7 +119,6 @@ const SearchResult = () => {
           // `/api/search/book?title=${title}&target=page&page=${currentPage-1}&size=${booksPerPage}`
           `/api/search/book?title=${title}&target=page&page=0&size=999`
         );
-        // console.log(response.data);
         setBooks(response.data);
         setLoading(false);
       } catch (error) {
@@ -101,10 +127,9 @@ const SearchResult = () => {
     };
     getSearchResults();
   }, [title]);
-  
+
   let searchResultsCount = books.length;
   searchResultsCount = searchResultsCount.toLocaleString();
-  let searchResultsKeywordCount = 123;
   let reviewCount = 123;
 
   // 10개, 50개, 100개에 따른 한페이지에 보여주는 책의 수
@@ -131,6 +156,13 @@ const SearchResult = () => {
     const updatedKeywordSet = new Set(selectedKeywordSet);
     updatedKeywordSet.delete(keyword);
     setSelectedKeywordSet(updatedKeywordSet);
+  };
+
+  // 검색된 키워드 삭제
+  const handleRemoveSearchedKeyword = (keyword) => {
+    setSearchedSelectedKeywords(
+      searchedSelectedKeywords.filter((k) => k !== keyword)
+    );
   };
 
   // 아래 키 기능
@@ -160,101 +192,44 @@ const SearchResult = () => {
 
         <SearchTitle id="search-title">
           <Title>
-            <span style={{ color: "#67B6C1" }}>"{title}"</span> 에 대한
-            <span style={{ color: "#67B6C1" }}>
-              {" "}
-              {searchResultsCount} 개의 검색 결과
-            </span>
+            <Highlight>"{title}"</Highlight> 에 대한
+            <Highlight> {searchResultsCount} 개의 검색 결과</Highlight>
           </Title>
         </SearchTitle>
 
         <ContentsWrap>
           <aside>
             <ContentTitle>키워드 검색</ContentTitle>
-            {/* <select name="" id="">
-              {books.map((book) => {
-                book.bookKeywordList.map((keyword, index) => {
-                  return (
-                    <option key={index} value={keyword.name}>
-                      {keyword.name}
-                    </option>
-                  );
-                });
-              })}
-            </select> */}
-            <select name="select-keyword" id="">
-              {books.flatMap((book) =>
-                book.bookKeywordList.map((keyword) => (
-                  <option value={keyword.name}>{keyword.name}</option>
-                ))
-              )}
-            </select>
-
-            <Input
-              type="text"
-              placeholder="키워드 추가"
-              style={{
-                borderRadius: "10px",
-                border: "1px solid #6B6565",
-                padding: "8px 8px 8px 12px",
-                fontSize: "1rem",
-              }}
+            <KeywordSearchBox
+              bookData={filteredBooks}
+              selectedKeywords={searchedSelectedKeywords}
+              setSelectedKeywords={setSearchedSelectedKeywords}
             />
           </aside>
 
           <section style={{ paddingLeft: "2.5rem", width: "100%" }}>
             {/* 헤더 영역 */}
-            <div
-              style={{
-                width: "100%",
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "center",
-                paddingBottom: "20px",
-                borderBottom: "1px solid #c4bebe",
-              }}
-            >
+            <HeaderArea>
               <ContentTitle>
-                전체{" "}
-                <span style={{ color: "#67B6C1" }}>{searchResultsCount}건</span>
+                전체 <Highlight>{filteredBooks.length}</Highlight>건
               </ContentTitle>
               <div>
                 <div style={{ display: "flex" }}>
-                  <select
-                    name=""
-                    id=""
-                    style={{
-                      width: "130px",
-                      border: "1px solid #C0C0C0 ",
-                      padding: "0px 10px",
-                      borderRadius: "5px",
-                      // marginRight: "10px",
-                    }}
-                  >
-                    {/* <option value="" selected> */}
+                  <SelectStyled name="sortOption" id="sort-option-select">
                     <option value="popular">인기순</option>
                     <option value="ranked">평점순</option>
-                  </select>
-                  <select
-                    name=""
-                    id=""
-                    style={{
-                      width: "130px",
-                      border: "1px solid #C0C0C0 ",
-                      padding: "0px 10px",
-                      borderRadius: "5px",
-                      marginLeft: "10px",
-                      marginRight: "10px",
-                    }}
+                  </SelectStyled>
+                  <SelectStyled
+                    name="itemsPerPage"
+                    id="items-per-page-select"
                     onChange={handleSizeChange}
                     value={booksPerPage}
                   >
-                    {/* <option value="10" selected> */}
                     <option value="10">10개씩 보기</option>
                     <option value="50">50개씩 보기</option>
                     <option value="100">100개씩 보기</option>
-                  </select>
-                  <div
+                  </SelectStyled>
+                  <ViewModeContainer
                     style={{
                       display: "flex",
                       width: "75px",
@@ -263,36 +238,29 @@ const SearchResult = () => {
                       // marginLeft: "10px",
                     }}
                   >
-                    <button
+                    <ViewButton
                       onClick={() => setViewMode(true)}
-                      style={{
-                        padding: "10px",
-                        backgroundColor: viewMode ? "#d0d0d0" : "white",
-                        borderRight: "1px solid #C0C0C0",
-                      }}
+                      active={viewMode}
+                      rightBorder
                     >
                       <img
                         src="https://contents.kyobobook.co.kr/resources/fo/images/common/ink/ico_view_list_active.png"
-                        alt=""
+                        alt="리스트 뷰"
                       />
-                    </button>
-                    <button
+                    </ViewButton>
+                    <ViewButton
                       onClick={() => setViewMode(false)}
-                      style={{
-                        padding: "10px",
-                        width: "100%",
-                        backgroundColor: viewMode ? "white" : "#d0d0d0",
-                      }}
+                      active={!viewMode}
                     >
                       <img
                         src="https://contents.kyobobook.co.kr/resources/fo/images/common/ink/ico_view_img_active.png"
-                        alt=""
+                        alt="카드 뷰"
                       />
-                    </button>
-                  </div>
+                    </ViewButton>
+                  </ViewModeContainer>
                 </div>
               </div>
-            </div>
+            </HeaderArea>
 
             {/* 키워드 영역 */}
             <div
@@ -302,19 +270,34 @@ const SearchResult = () => {
               }}
             >
               <ul style={{ display: "flex" }}>
-                <SearchKeyword>
-                  {/* <div>저주</div> */}
-                  저주
-                  <button
-                    style={{
-                      backgroundColor: "#c8edf2",
-                      borderRadius: "999px",
-                      lineHeight: "5px",
+                {/* <SearchKeyword>
+                    저주
+                    <button
+                      style={{
+                        backgroundColor: "#c8edf2",
+                        borderRadius: "999px",
+                        lineHeight: "5px",
+                      }}
+                    >
+                      <img src={closeIcon} alt="" />
+                    </button>
+                  </SearchKeyword>
+                  <Pill
+                    // key={index}
+                    // text={keyword}
+                    text={"저주"}
+                    onClick={() => {
+                      handleRemoveKeyword("저주");
                     }}
-                  >
-                    <img src={closeIcon} alt="" />
-                  </button>
-                </SearchKeyword>
+                  /> */}
+                {/* {selectedKeywords.map((keyword, index) => ( */}
+                {searchedSelectedKeywords.map((keyword, index) => (
+                  <Pill
+                    key={index}
+                    text={keyword}
+                    onClick={() => handleRemoveSearchedKeyword(keyword)}
+                  />
+                ))}
               </ul>
             </div>
 
@@ -521,7 +504,7 @@ const SearchResult = () => {
             </div>
             <Pagination
               booksPerPage={booksPerPage}
-              totalBooks={books.length}
+              totalBooks={filteredBooks.length}
               paginate={paginate}
               bookTitle={title}
               currentPage={currentPage}
@@ -535,10 +518,174 @@ const SearchResult = () => {
 
 export default SearchResult;
 
+const KeywordSearchBox = ({
+  bookData,
+  selectedKeywords,
+  setSelectedKeywords,
+}) => {
+  const [totalBooksOfKeywords, setTotalBooksOfKeywords] = useState([]); // 전체 키워드
+  const [isShowModal, setIsShowModal] = useState(false); // 모달 상태
+   const [searchTerm, setSearchTerm] = useState("");
+  // 모달과 모달을 열기 위한 버튼에 대한 참조 생성
+  const modalRef = useRef(null);
+  const buttonRef = useRef(null);
+
+
+  useEffect(() => {
+    setTotalBooksOfKeywords([]); // 키워드 초기화
+    const newKeywords = bookData.flatMap((data) => {
+      const keywords = data.bookKeywordList.map((keyword) => keyword.name);
+      return [data.middleCategoryName, ...keywords];
+    });
+    setTotalBooksOfKeywords((prev) => [...prev, ...new Set(newKeywords)]); // 중복 제거
+  }, [bookData]);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      // 모달이 열려 있고, 클릭한 요소가 모달 또는 버튼이 아닐 때만 모달을 닫음
+      if (
+        isShowModal &&
+        modalRef.current &&
+        !modalRef.current.contains(event.target) &&
+        !buttonRef.current.contains(event.target)
+      ) {
+        setIsShowModal(false);
+      }
+    };
+
+    // 문서에 클릭 이벤트 리스너 추가
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      // 컴포넌트 언마운트 시 이벤트 리스너 제거
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isShowModal]);
+
+  const handleShowModal = () => {
+    setIsShowModal(true);
+  };
+
+  const handleSelectKeyword = (keyword) => {
+    if (!selectedKeywords.includes(keyword)) {
+      setSelectedKeywords((prevKeywords) => [...prevKeywords, keyword]);
+    }
+  };
+
+ 
+  const availableKeywords = totalBooksOfKeywords.filter(
+    (keyword) =>
+      // 선택된 키워드 포함 x, 입력된 문자 포함
+      !selectedKeywords.includes(keyword) &&
+      keyword.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  return (
+    <>
+      <Input
+        type="text"
+        placeholder="키워드 추가"
+        onClick={handleShowModal}
+        ref={buttonRef}
+        onChange={(e) => setSearchTerm(e.target.value)}
+      />
+      {isShowModal ? (
+        <div ref={modalRef}>
+          <KeywordSearchBoxModal
+            // keywordData={totalBooksOfKeywords}
+            keywordData={availableKeywords}
+            onSelectKeyword={handleSelectKeyword}
+          />
+        </div>
+      ) : null}
+    </>
+  );
+};
+
+const KeywordSearchBoxModal = ({ keywordData, onSelectKeyword }) => {
+  return (
+    <>
+      <ModalStyled>
+        <ul>
+          {keywordData.map((keyword, index) => (
+            <li key={index} onClick={() => onSelectKeyword(keyword)}>
+              {keyword}
+            </li>
+          ))}
+        </ul>
+      </ModalStyled>
+    </>
+  );
+};
+
+const ModalStyled = styled.div`
+  width: 100%;
+  background-color: aliceblue;
+  cursor: pointer;
+  max-height: 300px;
+  overflow-y: auto;
+  border: 1px solid #ccc;
+  border-radius: 10px;
+  padding: 10px;
+  margin-top: 4px;
+  
+  li {
+    padding: 5px;
+  }
+`;
+
 const Main = styled.main`
   padding-top: 48px;
   max-width: 1440px;
   margin: 0 auto;
+`;
+
+// 검색창 관련
+
+// 타이틀 관련
+
+// 키워드 검색 관련
+
+// 책 결과 관련
+const ContentTitle = styled.h2`
+  font-size: 20px;
+  font-weight: bold;
+  margin-bottom: 20px;
+`;
+
+const Highlight = styled.span`
+  color: #67b6c1;
+`;
+
+const SelectStyled = styled.select`
+  width: 130px;
+  border: 1px solid #c0c0c0;
+  padding: 0px 10px;
+  border-radius: 5px;
+  margin-right: 10px;
+`;
+
+const HeaderArea = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #c4bebe;
+`;
+
+const ViewModeContainer = styled.div`
+  display: flex;
+  width: 75px;
+  border: 1.5px solid #c0c0c0;
+  border-radius: 5px;
+`;
+
+const ViewButton = styled.button`
+  padding: 10px;
+  width: 100%;
+  background-color: ${(props) => (props.active ? "#d0d0d0" : "white")};
+  border-right: ${(props) =>
+    props.rightBorder ? "1px solid #C0C0C0" : "none"};
 `;
 
 const SearchTitle = styled.section`
@@ -548,13 +695,7 @@ const SearchTitle = styled.section`
 const Title = styled.h1`
   font-size: 30px;
   font-weight: bold;
-
-  span {
-    color: #67b6c1;
-  }
 `;
-
-
 
 const SearchInputWrap = styled.div`
   width: 100%;
@@ -596,19 +737,12 @@ const ContentsWrap = styled.div`
   display: flex;
 `;
 
-const ContentTitle = styled.h2`
-  font-size: 20px;
-  font-weight: bold;
-  margin-bottom: 20px;
-`;
-
 const Input = styled.input`
   border-radius: 10px;
   border: 1px solid #6b6565;
   padding: 8px 8px 8px 12px;
   font-size: 1rem;
 `;
-
 
 const SearchKeyword = styled.li`
   display: flex;

--- a/src/pages/SearchResult.jsx
+++ b/src/pages/SearchResult.jsx
@@ -278,7 +278,7 @@ const SearchResult = () => {
                 <ListUIWrap>
                   {/* {books.map((book, index) => ( */}
                   {currentBooks.map((book, index) => (
-                    <Link to={`/book-detail/${book.title}`}>
+                    <Link to={`/book-detail/${book.isbn}`}>
                       <li
                         key={index}
                         style={{

--- a/src/pages/SearchResult.jsx
+++ b/src/pages/SearchResult.jsx
@@ -55,7 +55,7 @@ const SearchResult = () => {
 
     try {
       const response = await api.get(endpoint);
-      console.log("test", searchType, response.data);
+      // console.log("test", searchType, response.data);
       setSearchData(response.data);
     } catch (error) {
       console.error("Failed to fetch books:", error);

--- a/src/pages/SearchResult.jsx
+++ b/src/pages/SearchResult.jsx
@@ -490,7 +490,7 @@ const SearchResult = () => {
 export default SearchResult;
 
 const Main = styled.main`
-  padding: 48px 52px 0px 52px;
+  padding-top: 48px;
   max-width: 1440px;
   margin: 0 auto;
 `;

--- a/src/pages/SearchResult.jsx
+++ b/src/pages/SearchResult.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import Header from "../components/Header";
 import styled from "styled-components";
@@ -7,6 +7,7 @@ import starIcon from "../assets/icons8-별-30 (1).png";
 import api from "./../services/api";
 import Pagination from "../components/Pagination";
 import SearchBox from "../components/SearchBox";
+import Pill from "../components/Pill";
 
 const SearchResult = () => {
   const navigate = useNavigate();
@@ -21,6 +22,12 @@ const SearchResult = () => {
   const [searchType, setSearchType] = useState("title"); // 검색 유형 상태
   const [searchData, setSearchData] = useState([]); // 검색 결과 데이터
   const [isShow, setIsShow] = useState(false); // 검색창 모달창
+  const inputRef = useRef(null);
+
+  const [selectedKeywords, setSelectedKeywords] = useState([]);
+  const [selectedKeywordSet, setSelectedKeywordSet] = useState(new Set());
+
+
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -65,14 +72,14 @@ const SearchResult = () => {
   // 현재 책들 정보
   const indexOfLastBook = currentPage * booksPerPage;
   const indexOfFirstBook = indexOfLastBook - booksPerPage;
-  console.log(indexOfFirstBook, indexOfLastBook);
+  // console.log(indexOfFirstBook, indexOfLastBook);
   const currentBooks = books.slice(indexOfFirstBook, indexOfLastBook);
 
   // 페이지 변경
   const paginate = (pageNumber) => setCurrentPage(pageNumber);
 
-  console.log(books.length);
-  console.log(currentBooks);
+  // console.log(books.length);
+  // console.log(currentBooks);
 
   useEffect(() => {
     const getSearchResults = async () => {
@@ -82,7 +89,7 @@ const SearchResult = () => {
           // `/api/search/book?title=${title}&target=page&page=${currentPage-1}&size=${booksPerPage}`
           `/api/search/book?title=${title}&target=page&page=0&size=999`
         );
-        console.log(response.data);
+        // console.log(response.data);
         setBooks(response.data);
         setLoading(false);
       } catch (error) {
@@ -100,6 +107,27 @@ const SearchResult = () => {
   const handleSizeChange = (event) => {
     setBooksPerPage(event.target.value);
   };
+
+  const handleSelectKeyword = (keyword) => {
+    setSelectedKeywords([...selectedKeywords, keyword]);
+    setSelectedKeywordSet(new Set([...selectedKeywordSet, keyword]))
+    setInput("");
+    setSearchData([]);
+    inputRef.current.focus();
+  }
+
+  const handleRemoveKeyword = (keyword) => {
+    const updatedKeywords = selectedKeywords.filter((selectedKeyword) =>
+      selectedKeyword !== keyword
+    );
+    setSelectedKeywords(updatedKeywords);
+
+    const updatedKeywordSet = new Set(selectedKeywordSet);
+    updatedKeywordSet.delete(keyword);
+    setSelectedKeywordSet(updatedKeywordSet);
+  }
+  
+
 
   return (
     <>
@@ -125,6 +153,11 @@ const SearchResult = () => {
           setIsShow={setIsShow}
           searchBook={searchBook}
           searchData={searchData}
+          handleSelectKeyword={handleSelectKeyword}
+          selectedKeyword={selectedKeywords}
+          selectedKeywordSet={selectedKeywordSet}
+          handleRemoveKeyword={handleRemoveKeyword}
+          inputRef={inputRef}
         />
 
         <section id="search-title" style={{ marginBottom: "80px" }}>
@@ -185,10 +218,11 @@ const SearchResult = () => {
                       // marginRight: "10px",
                     }}
                   >
-                    <option value="" selected>
+                    {/* <option value="" selected> */}
+                    <option value="popular">
                       인기순
                     </option>
-                    <option value="">평점순</option>
+                    <option value="ranked">평점순</option>
                   </select>
                   <select
                     name=""
@@ -203,7 +237,8 @@ const SearchResult = () => {
                     onChange={handleSizeChange}
                     value={booksPerPage}
                   >
-                    <option value="10" selected>
+                    {/* <option value="10" selected> */}
+                    <option value="10">
                       10개씩 보기
                     </option>
                     <option value="50">50개씩 보기</option>
@@ -278,9 +313,8 @@ const SearchResult = () => {
                 <ListUIWrap>
                   {/* {books.map((book, index) => ( */}
                   {currentBooks.map((book, index) => (
-                    <Link to={`/book-detail/${book.isbn}`}>
+                    <Link key={index} to={`/book-detail/${book.isbn}`}>
                       <li
-                        key={index}
                         style={{
                           height: "310px",
                           display: "flex",

--- a/src/pages/SearchResult.jsx
+++ b/src/pages/SearchResult.jsx
@@ -28,10 +28,7 @@ const SearchResult = () => {
   const [selectedKeywords, setSelectedKeywords] = useState([]);
   const [selectedKeywordSet, setSelectedKeywordSet] = useState(new Set());
 
-
   const [searchedSelectedKeywords, setSearchedSelectedKeywords] = useState([]);
-  
-
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -80,18 +77,7 @@ const SearchResult = () => {
     }
   };
 
-  // 키워드로 어떻게 담지?
-
-  // const { searchedSelectedKeywords,removeKeyword } = useSearchedSelectedKeywords();
-  // console.log(searchedSelectedKeywords)
-
-  // 현재 책들 정보
-  // const filteredBooks = books.filter(
-  //   (book) =>
-  //     book.bookKeywordList.some((keyword) =>
-  //       searchedSelectedKeywords.includes(keyword.name)
-  //     ) || searchedSelectedKeywords.includes(book.middleCategoryName)
-  // );
+  // 키워드로 책 필터링
   const filteredBooks = books.filter((book) =>
     searchedSelectedKeywords.every(
       (keyword) =>
@@ -100,8 +86,6 @@ const SearchResult = () => {
         ) || keyword === book.middleCategoryName
     )
   );
-
-  console.log("Filtered Books: ", filteredBooks);
 
   const indexOfLastBook = currentPage * booksPerPage;
   const indexOfFirstBook = indexOfLastBook - booksPerPage;
@@ -270,27 +254,6 @@ const SearchResult = () => {
               }}
             >
               <ul style={{ display: "flex" }}>
-                {/* <SearchKeyword>
-                    저주
-                    <button
-                      style={{
-                        backgroundColor: "#c8edf2",
-                        borderRadius: "999px",
-                        lineHeight: "5px",
-                      }}
-                    >
-                      <img src={closeIcon} alt="" />
-                    </button>
-                  </SearchKeyword>
-                  <Pill
-                    // key={index}
-                    // text={keyword}
-                    text={"저주"}
-                    onClick={() => {
-                      handleRemoveKeyword("저주");
-                    }}
-                  /> */}
-                {/* {selectedKeywords.map((keyword, index) => ( */}
                 {searchedSelectedKeywords.map((keyword, index) => (
                   <Pill
                     key={index}
@@ -305,7 +268,6 @@ const SearchResult = () => {
             <div>
               {viewMode ? (
                 <ListUIWrap>
-                  {/* {books.map((book, index) => ( */}
                   {currentBooks.map((book, index) => (
                     <Link key={index} to={`/book-detail/${book.isbn}`}>
                       <li
@@ -425,7 +387,6 @@ const SearchResult = () => {
                 </ListUIWrap>
               ) : (
                 <CardUIWrap>
-                  {/* {books.map((book, index) => ( */}
                   {currentBooks.map((book, index) => (
                     <Link to={`/book-detail/${book.title}`}>
                       <li key={index} style={{ width: "170px" }}>
@@ -525,11 +486,10 @@ const KeywordSearchBox = ({
 }) => {
   const [totalBooksOfKeywords, setTotalBooksOfKeywords] = useState([]); // 전체 키워드
   const [isShowModal, setIsShowModal] = useState(false); // 모달 상태
-   const [searchTerm, setSearchTerm] = useState("");
+  const [searchTerm, setSearchTerm] = useState("");
   // 모달과 모달을 열기 위한 버튼에 대한 참조 생성
   const modalRef = useRef(null);
   const buttonRef = useRef(null);
-
 
   useEffect(() => {
     setTotalBooksOfKeywords([]); // 키워드 초기화
@@ -571,7 +531,6 @@ const KeywordSearchBox = ({
     }
   };
 
- 
   const availableKeywords = totalBooksOfKeywords.filter(
     (keyword) =>
       // 선택된 키워드 포함 x, 입력된 문자 포함
@@ -627,7 +586,7 @@ const ModalStyled = styled.div`
   border-radius: 10px;
   padding: 10px;
   margin-top: 4px;
-  
+
   li {
     padding: 5px;
   }

--- a/src/styles/SearchStyles.css
+++ b/src/styles/SearchStyles.css
@@ -58,8 +58,8 @@
   width: 50px;
   height: 40px;
   font-size: 1.5rem;
-  position: absolute;
-  right: 70px;
+  position: relative;
+  right: 0;
   background-color: #fff;
 }
 


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #102 

### ✅ 작업한 내용
- 검색 결과에 나온 모든 책들의 키워드로 필터링 검색 기능 추가
- 키워드 추가 시, 검색된 책의 수, 페이지네이션 페이지의 수 변경되도록 적용
- 키워드 검색 가능하며 스크롤로 사용 가능하도록 구현
- 검색 창 클릭 시, 모달창 열기를 useRef를 통해 DOM으로 접근하여 열고 닫기 이벤트를 적용시킴

### ❗️PR Point
- 검색 페이지 관련 컴포넌트 설계를 다시 한번 해봐야할 필요성을 느낌 -> 코드가 번잡함
- state와 props의 관리 부족으로 인하여 한번 호출되는 것이 아닌 여러번 호출되는 버그가 발생함
- 필터링 클릭시, 화면이 맨위로 올라가는 버그 발생
- 선택된 모든 키워드 리셋 버튼 필요

### 📸 스크린샷
![image](https://github.com/kw-bookmedicine/FE2/assets/96184691/18d6288d-eb91-4db4-b76a-8cd3f49931a3)
<키워드 검색창>

![image](https://github.com/kw-bookmedicine/FE2/assets/96184691/ef07321b-f4d1-41a9-b9d4-75711b94bcc2)
<키워드 추가 하여 필터링된 결과>

![image](https://github.com/kw-bookmedicine/FE2/assets/96184691/1458bdbb-e18b-4f9c-afb3-fa5565b3d7b6)
<'생' 을 검색 시, '생' 관련 키워드 보여줌>

closed #102 
