### PR TITLE
✨  Feat: worry-detail 페이지 api.prescription 게시물에 대한 처방전 조회 api 연결

### DIFF
--- a/src/components/Prescription/WidePrescriptionCard.jsx
+++ b/src/components/Prescription/WidePrescriptionCard.jsx
@@ -1,53 +1,69 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React from "react";
+import { Link } from "react-router-dom";
 
-import '../../styles/Prescription/WidePrescriptionCard.css';
+import "../../styles/Prescription/WidePrescriptionCard.css";
+import { toYYYYMMDD } from "../../util/toYYYYMMDD";
 
-const WidePrescriptionCard = () => {
-	return (
-		<>
-			<Link to={'/prescription/detail'}>
-				<div className="WidePrscrCard_container">
-					<div className="wide_prscr_left_wrapper">
-						<div className="wide_prscr_left_img">
-							<img src="/icon/pharmacy_icon.png" alt="" />
-						</div>
-						<div className="wide_prscr_left_title">
-							"새로운 곳에 적응하기 힘들어요"
-						</div>
-						<div className="wide_prscr_left_profile">
-							<div className="wide_prscr_profile_img"></div>
-							<div className="wide_prscr_profileInfo_wrapper">
-								<p className="profileInfo_nickname">나는 행복합니다</p>
-								<p className="profileInfo_date">2024.04.10.</p>
-							</div>
-						</div>
-					</div>
-					<div className="wide_prscr_mid_line"></div>
-					<div className="wide_prscr_right_wrapper">
-						<div className="wide_prscr_rl_wrapper">
-							<img src="/loading_thumbnail_x4.png" alt="" />
-						</div>
-						<div className="wide_prscr_rr_wrapper">
-							<div className="wide_prscr_rr_top_wrapper">
-								<p className="wide_prscr_bookInfo_title">책 제목</p>
-								<p className="wide_prscr_bookInfo_author">저자</p>
-								<p className="wide_prscr_bookInfo_date">출판사/출판연도</p>
-							</div>
-							<div className="wide_prscr_rr_bottom_wrapper">
-								<div className="wide_prscr_rr_reason_title">처방사유</div>
-								<div className="wide_prscr_rr_reason_box"></div>
-							</div>
-						</div>
-					</div>
-					<img
-						src="/icon/pharmacy_icon_2.png"
-						className="wide_prscr_pharmacy_icon_group"
-					/>
-				</div>
-			</Link>
-		</>
-	);
+const WidePrescriptionCard = ({ props }) => {
+  const {
+    title,
+    description,
+    createdDate,
+    nickname,
+    bookTitle,
+    author,
+    publishingHouse,
+    publishYear,
+    imageUrl,
+  } = props;
+  return (
+    <>
+      <Link to={"/prescription/detail"}>
+        <div className="WidePrscrCard_container">
+          <div className="wide_prscr_left_wrapper">
+            <div className="wide_prscr_left_img">
+              <img src="/icon/pharmacy_icon.png" alt="" />
+            </div>
+            <div className="wide_prscr_left_title">{title}</div>
+            <div className="wide_prscr_left_profile">
+              <div className="wide_prscr_profile_img"></div>
+              <div className="wide_prscr_profileInfo_wrapper">
+                <p className="profileInfo_nickname">{nickname}</p>
+                <p className="profileInfo_date">{toYYYYMMDD(createdDate)}</p>
+              </div>
+            </div>
+          </div>
+          <div className="wide_prscr_mid_line"></div>
+          <div className="wide_prscr_right_wrapper">
+            <div className="wide_prscr_rl_wrapper">
+              <img src={imageUrl || "/loading_thumbnail_x4.png"} alt="" />
+            </div>
+            <div className="wide_prscr_rr_wrapper">
+              <div className="wide_prscr_rr_top_wrapper">
+                <p className="wide_prscr_bookInfo_title">{bookTitle}</p>
+                <p className="wide_prscr_bookInfo_author">{author}</p>
+                <p className="wide_prscr_bookInfo_date">
+                  {publishingHouse || "null값"}/{publishYear || "출판연도"}
+                </p>
+              </div>
+              <div className="wide_prscr_rr_bottom_wrapper">
+                <div className="wide_prscr_rr_reason_title">처방사유</div>
+                <div className="wide_prscr_rr_reason_box">
+                  <div className="wide_prscr_rr_reason_box_content">
+                    <p>{description}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <img
+            src="/icon/pharmacy_icon_2.png"
+            className="wide_prscr_pharmacy_icon_group"
+          />
+        </div>
+      </Link>
+    </>
+  );
 };
 
 export default WidePrescriptionCard;

--- a/src/pages/Worry/WorryDetail.jsx
+++ b/src/pages/Worry/WorryDetail.jsx
@@ -1,98 +1,113 @@
-import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 
 // COMPONENTS
-import Header from './../../components/Header';
-import Title from '../../components/Prescription/ProcessTitle';
-import WidePrscrCard from '../../components/Prescription/WidePrescriptionCard';
+import Header from "./../../components/Header";
+import Title from "../../components/Prescription/ProcessTitle";
+import WidePrscrCard from "../../components/Prescription/WidePrescriptionCard";
 
 // SERVICE
-import api from '../../services/api';
+import api from "../../services/api";
 
 // STYLE
-import '../../styles/Counseling/WorryDetail.css';
+import "../../styles/Counseling/WorryDetail.css";
 
 const WorryDetail = () => {
-	const [boardData, setBoardData] = useState({});
+  const [boardData, setBoardData] = useState({});
+  const [prescriptionData, setPrescriptionData] = useState([]);
 
-	// 해당하는 고민 글 정보 가져오기
-	const fetchData = () => {
-		const currentUrl = window.location.href;
+  const currentUrl = window.location.href;
 
-		// URL에서 boardId 쿼리 파라미터 값을 추출
-		const urlParams = new URLSearchParams(new URL(currentUrl).search);
-		const boardId = urlParams.get('board');
-		try {
-			if (!boardId) {
-				console.error('주소에 boardId가 없습니다.');
-				return;
-			}
-			api.get(`/api/board/${boardId}`).then((res) => {
-				setBoardData(res.data);
-				console.log(res.data);
-			});
-		} catch (err) {
-			console.log(err);
-		}
-	};
+  // URL에서 boardId 쿼리 파라미터 값을 추출
+  const urlParams = new URLSearchParams(new URL(currentUrl).search);
+  const boardId = urlParams.get("board");
 
-	useEffect(() => {
-		fetchData();
-	}, []);
+  // 해당하는 고민 글 정보 가져오기
+  const fetchData = () => {
+    try {
+      if (!boardId) {
+        console.error("주소에 boardId가 없습니다.");
+        return;
+      }
+      api.get(`/api/board/${boardId}`).then((res) => {
+        setBoardData(res.data);
+        console.log(res.data);
+      });
+    } catch (err) {
+      console.log(err);
+    }
+  };
 
-	const move = () => {
-		window.location.replace('/pre/write');
-	};
+  // 해당 고민 글의 처방전 조회
+  const fetchPrescription = async () => {
+    try {
+      const response = await api.get(
+        `/api/prescription?page=0&size=99&boardId=${boardId}`
+      );
+      setPrescriptionData(response.data);
+    } catch (error) {
+      console.log("해당 글 처방전 조회 실패", error);
+    }
+  };
 
-	return (
-		<>
-			<Header />
-			<div className="worry_detail_content">
-				<Title type={'normal'} value={boardData.nickname} />
-				<div className="worry_detail_title_wrapper">
-					<div className="wd_user_wrapper">
-						<div className="wd_user_left_wrapper">
-							<div className="wd_user_img">
-								<img
-									src="/icon/profile/basic_profile_img.svg"
-									alt="유저 프로필"
-									className="wd_user_img"
-								/>
-							</div>
-							<div className="wd_user_info_wrapper">
-								<div className="wd_user_name">{boardData.nickname}</div>
-								<div className="wd_user_date">
-									{boardData.createdDate
-										? boardData.createdDate.slice(0, 10)
-										: null}
-								</div>
-							</div>
-						</div>
-					</div>
-					<div className="wd_title_text_wrapper">{boardData.title}</div>
-				</div>
-				<div className="worry_detail_content_wrapper">
-					<div className="wd_content_detail_wrapper">
-						<span className="wd_content_detail_title">처방사유</span>
-						<div className="wd_content_detail_text">
-							{boardData.description}
-						</div>
-					</div>
-					<div className="worry_detail_prscr_wrapper">
-						<div className="wd_prscr_list_title">처방전 확인하기</div>
-						<div className="wd_prscr_list_wrapper">
-							<WidePrscrCard />
-							<WidePrscrCard />
-							<WidePrscrCard />
-						</div>
-					</div>
-					<Link to={`/prescription/write?prscrId=123`}>
-						<button className="prscr_btn">처방하러 가기</button>
-					</Link>
-				</div>
-			</div>
-		</>
-	);
+  useEffect(() => {
+    fetchData();
+    fetchPrescription();
+  }, []);
+
+  const move = () => {
+    window.location.replace("/pre/write");
+  };
+
+  return (
+    <>
+      <Header />
+      <div className="worry_detail_content">
+        <Title type={"normal"} value={boardData.nickname} />
+        <div className="worry_detail_title_wrapper">
+          <div className="wd_user_wrapper">
+            <div className="wd_user_left_wrapper">
+              <div className="wd_user_img">
+                <img
+                  src="/icon/profile/basic_profile_img.svg"
+                  alt="유저 프로필"
+                  className="wd_user_img"
+                />
+              </div>
+              <div className="wd_user_info_wrapper">
+                <div className="wd_user_name">{boardData.nickname}</div>
+                <div className="wd_user_date">
+                  {boardData.createdDate
+                    ? boardData.createdDate.slice(0, 10)
+                    : null}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="wd_title_text_wrapper">{boardData.title}</div>
+        </div>
+        <div className="worry_detail_content_wrapper">
+          <div className="wd_content_detail_wrapper">
+            <span className="wd_content_detail_title">처방사유</span>
+            <div className="wd_content_detail_text">
+              {boardData.description}
+            </div>
+          </div>
+          <div className="worry_detail_prscr_wrapper">
+            <div className="wd_prscr_list_title">처방전 확인하기</div>
+            <div className="wd_prscr_list_wrapper">
+              {prescriptionData.map((prescription) => (
+                <WidePrscrCard key={prescription.id} props={prescription} />
+              ))}
+            </div>
+          </div>
+          <Link to={`/prescription/write?prscrId=123`}>
+            <button className="prscr_btn">처방하러 가기</button>
+          </Link>
+        </div>
+      </div>
+    </>
+  );
 };
 
 export default WorryDetail;

--- a/src/pages/Worry/WorryDetail.jsx
+++ b/src/pages/Worry/WorryDetail.jsx
@@ -31,7 +31,6 @@ const WorryDetail = () => {
       }
       api.get(`/api/board/${boardId}`).then((res) => {
         setBoardData(res.data);
-        console.log(res.data);
       });
     } catch (err) {
       console.log(err);

--- a/src/styles/Prescription/WidePrescriptionCard.css
+++ b/src/styles/Prescription/WidePrescriptionCard.css
@@ -1,188 +1,192 @@
 .WidePrscrCard_container {
-	display: flex;
-	width: 1125px;
-	height: 420px;
-	border: 5px solid #a4d6dd;
-	border-radius: 10px;
-	margin-left: 15px;
-	background-color: #fff;
+  display: flex;
+  width: 1125px;
+  height: 420px;
+  border: 5px solid #a4d6dd;
+  border-radius: 10px;
+  margin-left: 15px;
+  background-color: #fff;
 }
 
 .wide_prscr_left_wrapper {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	width: 40%;
-	/* background-color: yellow; */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 40%;
+  /* background-color: yellow; */
 }
 
 .wide_prscr_left_img {
-	width: 100%;
-	height: 50px;
-	display: flex;
-	justify-content: flex-start;
-	padding: 10px;
+  width: 100%;
+  height: 50px;
+  display: flex;
+  justify-content: flex-start;
+  padding: 10px;
 }
 
 .wide_prscr_left_img > img {
-	width: 30px;
-	height: 30px;
+  width: 30px;
+  height: 30px;
 }
 
 .wide_prscr_left_title {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	width: 100%;
-	height: 280px;
-	font-family: var(--basic-font);
-	font-weight: 600;
-	font-size: 30px;
-	font-style: normal;
-	line-height: 40px;
-	color: #000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 280px;
+  font-family: var(--basic-font);
+  font-weight: 600;
+  font-size: 30px;
+  font-style: normal;
+  line-height: 40px;
+  color: #000;
 }
 
 .wide_prscr_left_profile {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 100%;
-	height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 80px;
 }
 
 .wide_prscr_profile_img {
-	width: 30px;
-	height: 30px;
-	border-radius: 100%;
-	background-color: #a4d6dd;
-	margin-right: 10px;
+  width: 30px;
+  height: 30px;
+  border-radius: 100%;
+  background-color: #a4d6dd;
+  margin-right: 10px;
 }
 
 .wide_prscr_profileInfo_wrapper {
-	display: flex;
-	flex-direction: column;
-	font-family: var(--basic-font);
-	font-style: normal;
+  display: flex;
+  flex-direction: column;
+  font-family: var(--basic-font);
+  font-style: normal;
 }
 
 .profileInfo_nickname {
-	color: #000;
-	font-weight: 600;
-	font-size: 15px;
-	line-height: 18px;
+  color: #000;
+  font-weight: 600;
+  font-size: 15px;
+  line-height: 18px;
 }
 
 .profileInfo_date {
-	color: #868686;
-	font-weight: 400;
-	font-size: 14px;
-	line-height: 16px;
+  color: #868686;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 16px;
 }
 
 .wide_prscr_mid_line {
-	width: 3px;
-	height: 365px;
-	margin: 25px 0;
-	background-color: #a4d6dd;
+  width: 3px;
+  height: 365px;
+  margin: 25px 0;
+  background-color: #a4d6dd;
 }
 
 .wide_prscr_right_wrapper {
-	display: flex;
-	padding: 20px 10px;
-	width: 60%;
-	height: 100%;
+  display: flex;
+  padding: 20px 10px;
+  width: 60%;
+  height: 100%;
 }
 
 .wide_prscr_rl_wrapper {
-	display: flex;
-	align-items: center;
-	width: 30%;
-	height: 100%;
-	margin-left: 75px;
+  display: flex;
+  align-items: center;
+  width: 30%;
+  height: 100%;
+  margin-left: 75px;
 }
 
 .wide_prscr_rl_wrapper > img {
-	width: 200px;
-	height: 280px;
+  width: 200px;
+  height: 280px;
 }
 
 .wide_prscr_rr_wrapper {
-	display: flex;
-	flex-direction: column;
-	width: 70%;
-	height: 100%;
-	margin-left: 30px;
-	font-family: var(--basic-font);
-	font-style: normal;
+  display: flex;
+  flex-direction: column;
+  width: 70%;
+  height: 100%;
+  margin-left: 30px;
+  font-family: var(--basic-font);
+  font-style: normal;
 }
 
 .wide_prscr_rr_top_wrapper {
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	margin-top: 45px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 45px;
 }
 
 .wide_prscr_bookInfo_title {
-	margin-bottom: 10px;
-	font-family: var(--basic-font);
-	font-style: normal;
-	font-weight: 700;
-	font-size: 22px;
-	line-height: 24px;
-	color: #000;
+  margin-bottom: 10px;
+  font-family: var(--basic-font);
+  font-style: normal;
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 24px;
+  color: #000;
 }
 
 .wide_prscr_bookInfo_author,
 .wide_prscr_bookInfo_date {
-	font-family: var(--basic-font);
-	font-style: normal;
-	font-weight: 600;
-	font-size: 18px;
-	line-height: 21px;
-	color: #868686;
+  font-family: var(--basic-font);
+  font-style: normal;
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 21px;
+  color: #868686;
 }
 
 .wide_prscr_rr_bottom_wrapper {
-	position: sticky;
-	width: 100%;
-	height: 80%;
-	display: flex;
-	flex-direction: column;
-	margin-top: 20px;
+  position: sticky;
+  width: 100%;
+  height: 80%;
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
 }
 
 .wide_prscr_rr_reason_title {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	position: absolute;
-	top: -12px;
-	left: 20px;
-	width: 80px;
-	height: 30px;
-	font-family: 'HakgyoansimWoojuR';
-	font-weight: 700;
-	font-size: 16px;
-	font-style: normal;
-	line-height: 19px;
-	background-color: #fff;
-	color: #a4d6dd;
-	z-index: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: -12px;
+  left: 20px;
+  width: 80px;
+  height: 30px;
+  font-family: "HakgyoansimWoojuR";
+  font-weight: 700;
+  font-size: 16px;
+  font-style: normal;
+  line-height: 19px;
+  background-color: #fff;
+  color: #a4d6dd;
+  z-index: 1;
 }
 
 .wide_prscr_rr_reason_box {
-	width: 320px;
-	height: 185px;
-	border: 3px solid #a4d6dd;
-	border-radius: 10px;
+  width: 320px;
+  height: 185px;
+  border: 3px solid #a4d6dd;
+  border-radius: 10px;
+}
+
+.wide_prscr_rr_reason_box_content {
+  padding: 20px;
 }
 
 .wide_prscr_pharmacy_icon_group {
-	position: relative;
-	top: 352px;
-	right: 13px;
-	width: 50px;
-	height: 50px;
+  position: relative;
+  top: 352px;
+  right: 13px;
+  width: 50px;
+  height: 50px;
 }

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,0 +1,1 @@
+export * from "./toYYYYMMDD";

--- a/src/util/toYYYYMMDD.js
+++ b/src/util/toYYYYMMDD.js
@@ -1,0 +1,7 @@
+export function toYYYYMMDD(dateString) {
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0"); // 월은 0부터 시작하므로 1을 더해줍니다.
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}.${month}.${day}.`;
+}


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #187 

### ✅ 작업한 내용
- 날짜를 받으면 2024.05.07. 으로 변환하는 메서드 util 파일에 추가했습니다.  toYYYYMMDD
- 해당 고민 게시물의 처방전 조회 API 연결
- 처방사유에 내용에 대한 css 작업

### ❗️PR Point
데이터가 없어, 빈 공간일때 어떻게 보여줄 것인지 처리해야함 -> "아직 처방전이 없어요 or 처방전을 등록해봐요!" 등 보여주도록하기
아니면 아예 등록하기 버튼만 있어도 나쁘지 않을거같네요 

![image](https://github.com/kw-bookmedicine/frontend/assets/96184691/22e0bd60-9112-4f70-a9c3-523fb136ed12)

제목이 2줄이거나 저자명이 2줄을 한줄 처리로 할까 고민중입니다.
![image](https://github.com/kw-bookmedicine/frontend/assets/96184691/a426eb07-8713-4077-add2-a96e5686f463)

### 📸 스크린샷
![image](https://github.com/kw-bookmedicine/frontend/assets/96184691/5de046a8-d866-4fb2-8871-48283720b4b7)

closed #187 
