### PR TITLE
✨ Feat: 한 줄 처방전 상세보기 페이지 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,7 @@ import PrescriptionWriteStep2 from './pages/PrescriptionWriteStep2';
 import PrescriptionDetail from './pages/Prescription/PrescriptionDetail';
 import OneLinePrescription from './pages/Prescription/OneLinePrescription';
 import OneLinePrscrWrite from './pages/Prescription/OneLinePrscrWrite.jsx';
+import OneLinePrscrDetail from './pages/Prescription/OneLinePrscrDetail.jsx';
 
 // STYLE
 import GlobalStyles from './styles/GlobalStyles';
@@ -102,6 +103,10 @@ function App() {
 						<Route
 							path="/prescription/detail"
 							element={<PrescriptionDetail />}
+						/>
+						<Route
+							path="/oneline/prescription-detail"
+							element={<OneLinePrscrDetail />}
 						/>
 						<Route path="/myworry" element={<MyWorry />} />
 						{/* 회원가입 및 로그인 */}

--- a/src/components/Prescription/OneLinePrscrCard.jsx
+++ b/src/components/Prescription/OneLinePrscrCard.jsx
@@ -10,69 +10,71 @@ import { Link } from 'react-router-dom';
 const OneLinePrscrCard = ({ item }) => {
 	return (
 		<>
-			<div className="OneLinePrscrCard_wrapper">
-				<div className="oneLineCard_profile_wrapper">
-					<img
-						src="/icon/profile/basic_profile_img.svg"
-						alt="작성자 프로필"
-						id="oneLineCard_profile_img"
-					/>
-					<div className="oneLineCard_profile_userInfo_wrapper">
-						<p id="oneLineCard_user_nickname">{item.clientNickname}</p>
-						<p>2024.05.13</p>
-					</div>
-				</div>
-				<div className="oneLineCard_title_wrapper">
-					<p>{item.title}</p>
-				</div>
-				<div className="oneLineCard_bookInfo_wrapper">
-					<img
-						src={
-							item.bookImageUrl === null
-								? '/loading_thumbnail_x4.png'
-								: item.bookImageUrl
-						}
-						alt="책 썸네일"
-						id="oneLineCard_thumbnail"
-					/>
-					<div className="oneLineCard_bookInfo_right_wrapper">
-						<div className="oneLineCard_bookInfo_content_wrapper">
-							<div className="bookInfo_content_left_wrapper">
-								<p id="oneLineCard_bookInfo_bookTitle">{item.bookTitle}</p>
-								<p>{item.bookAuthor}</p>
-							</div>
-							<div className="showBook_btn_wrapper">
-								<Link to={`/book-detail?isbn=${item.bookIsbn}`}>
-									<button id="showBook_btn">책 보러가기</button>
-								</Link>
-							</div>
+			<Link to={`/oneline/prescription-detail?boardId=${item.id}`}>
+				<div className="OneLinePrscrCard_wrapper">
+					<div className="oneLineCard_profile_wrapper">
+						<img
+							src="/icon/profile/basic_profile_img.svg"
+							alt="작성자 프로필"
+							id="oneLineCard_profile_img"
+						/>
+						<div className="oneLineCard_profile_userInfo_wrapper">
+							<p id="oneLineCard_user_nickname">{item.clientNickname}</p>
+							<p>{item.createdDate}</p>
 						</div>
-						{/* <div className="oneLineCard_bookInfo_keyword_wrapper">
+					</div>
+					<div className="oneLineCard_title_wrapper">
+						<p>{item.title}</p>
+					</div>
+					<div className="oneLineCard_bookInfo_wrapper">
+						<img
+							src={
+								item.bookImageUrl === null
+									? '/loading_thumbnail_x4.png'
+									: item.bookImageUrl
+							}
+							alt="책 썸네일"
+							id="oneLineCard_thumbnail"
+						/>
+						<div className="oneLineCard_bookInfo_right_wrapper">
+							<div className="oneLineCard_bookInfo_content_wrapper">
+								<div className="bookInfo_content_left_wrapper">
+									<p id="oneLineCard_bookInfo_bookTitle">{item.bookTitle}</p>
+									<p>{item.bookAuthor}</p>
+								</div>
+								<div className="showBook_btn_wrapper">
+									<Link to={`/book-detail?isbn=${item.bookIsbn}`}>
+										<button id="showBook_btn">책 보러가기</button>
+									</Link>
+								</div>
+							</div>
+							{/* <div className="oneLineCard_bookInfo_keyword_wrapper">
 							<HashTag text={'저주'} type={'keyword'} />
 							<HashTag text={'해리포터'} type={'keyword'} />
 							<HashTag text={'판타지'} type={'keyword'} />
 						</div> */}
+						</div>
+					</div>
+					<div className="oneLineCard_evaluation_wrapper">
+						<div className="evaluation_wrapper">
+							<img
+								src="/icon/oneLine-prscr/like.png"
+								id="oneLineCard_like_icon"
+							/>
+							<span>좋은 추천이에요</span>
+							<span>20</span>
+						</div>
+						<div className="evaluation_wrapper">
+							<img
+								src="/icon/oneLine-prscr/laughing.png"
+								id="oneLineCard_good_icon"
+							/>
+							<span>도움이 되었어요</span>
+							<span>10</span>
+						</div>
 					</div>
 				</div>
-				<div className="oneLineCard_evaluation_wrapper">
-					<div className="evaluation_wrapper">
-						<img
-							src="/icon/oneLine-prscr/like.png"
-							id="oneLineCard_like_icon"
-						/>
-						<span>좋은 추천이에요</span>
-						<span>20</span>
-					</div>
-					<div className="evaluation_wrapper">
-						<img
-							src="/icon/oneLine-prscr/laughing.png"
-							id="oneLineCard_good_icon"
-						/>
-						<span>도움이 되었어요</span>
-						<span>10</span>
-					</div>
-				</div>
-			</div>
+			</Link>
 		</>
 	);
 };

--- a/src/components/Prescription/OneLinePrscrCard.jsx
+++ b/src/components/Prescription/OneLinePrscrCard.jsx
@@ -10,7 +10,9 @@ import { Link } from 'react-router-dom';
 const OneLinePrscrCard = ({ item }) => {
 	return (
 		<>
-			<Link to={`/oneline/prescription-detail?boardId=${item.id}`}>
+			<Link
+				to={`/oneline/prescription-detail?prscrId=${item.id}&bookIsbn=${item.bookIsbn}`}
+			>
 				<div className="OneLinePrscrCard_wrapper">
 					<div className="oneLineCard_profile_wrapper">
 						<img
@@ -43,9 +45,14 @@ const OneLinePrscrCard = ({ item }) => {
 									<p>{item.bookAuthor}</p>
 								</div>
 								<div className="showBook_btn_wrapper">
-									<Link to={`/book-detail?isbn=${item.bookIsbn}`}>
-										<button id="showBook_btn">책 보러가기</button>
-									</Link>
+									{/* <Link to={`/book-detail?isbn=${item.bookIsbn}`}> */}
+									<button
+										href={`/book-detail?isbn=${item.bookIsbn}`}
+										id="showBook_btn"
+									>
+										책 보러가기
+									</button>
+									{/* </Link> */}
 								</div>
 							</div>
 							{/* <div className="oneLineCard_bookInfo_keyword_wrapper">

--- a/src/pages/Prescription/OneLinePrscrDetail.jsx
+++ b/src/pages/Prescription/OneLinePrscrDetail.jsx
@@ -1,0 +1,17 @@
+import React, { useState, useEffect } from 'react';
+
+// COMPONENTS
+import Header from '../../components/Header';
+
+// STYLE
+import '../../styles/Prescription/OneLinePrscrDetail.css';
+
+const OneLinePrscrDetail = () => {
+	return (
+		<>
+			<Header />
+		</>
+	);
+};
+
+export default OneLinePrscrDetail;

--- a/src/pages/Prescription/OneLinePrscrDetail.jsx
+++ b/src/pages/Prescription/OneLinePrscrDetail.jsx
@@ -1,12 +1,60 @@
 import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 // COMPONENTS
 import Header from '../../components/Header';
+import HashTag from '../../components/HashTag';
+
+// SERVICE
+import api from '../../services/api';
 
 // STYLE
 import '../../styles/Prescription/OneLinePrscrDetail.css';
 
 const OneLinePrscrDetail = () => {
+	const [searchParams] = useSearchParams();
+	console.log(searchParams);
+	const prscrId = searchParams.get('prscrId');
+	const bookIsbn = searchParams.get('bookIsbn');
+	console.log(bookIsbn);
+	console.log(prscrId);
+
+	const [data, setData] = useState({});
+	const [bookData, setBookData] = useState({});
+	const [keywordArr, setKeywordArr] = useState([]);
+
+	const fetchData = () => {
+		try {
+			api.get(`/api/oneline-prescriptions/${prscrId}`).then((res) => {
+				console.log(res.data);
+				setData(res.data);
+			});
+		} catch (err) {
+			console.log(err);
+		}
+	};
+
+	const getBookData = () => {
+		try {
+			if (data.bookIsbn !== null) {
+				api.get(`/api/book/detail?isbn=${bookIsbn}`).then((res) => {
+					setBookData(res.data);
+					if (res.data.keywordItemList.length !== 0) {
+						setKeywordArr(res.data.keywordItemList);
+					}
+					console.log(res.data);
+				});
+			}
+		} catch (err) {
+			console.log(err);
+		}
+	};
+
+	useEffect(() => {
+		fetchData();
+		getBookData();
+	}, []);
+
 	return (
 		<>
 			<Header />
@@ -16,24 +64,46 @@ const OneLinePrscrDetail = () => {
 						<div className="prscr_detail_left_wrapper">
 							<div className="prscr_detail_img_wrapper">
 								<img
-									src="/loading_thumbnail_x4.png"
+									src={
+										data.bookImageUrl === null
+											? '/loading_thumbnail_x4.png'
+											: data.bookImageUrl
+									}
 									id="oneLine-prscr-book-img"
 								/>
 							</div>
 							<div className="prscr_detail_bookAbout_wrapper">
 								<p>책 정보</p>
-								<div className="bookAbout_content"></div>
-								<div className="bookKeyword_wrapper"></div>
+								<div className="bookAbout_content">
+									{bookData.content === null
+										? '책 정보를 준비 중입니다.'
+										: bookData.content}
+								</div>
+								<div className="bookKeyword_wrapper">
+									{keywordArr.map((item, idx) => {
+										return (
+											<HashTag
+												text={item.name}
+												type={'keyword'}
+												key={'키워드' + idx + '-' + item.name}
+											/>
+										);
+									})}
+								</div>
 							</div>
 						</div>
 						<div className="prscr_detail_right_wrapper">
 							<div className="prscr_detail_bookInfo_wrapper">
 								<div className="bookInfo_title_wrapper">
-									<p>책 제목</p>
+									<p>{data.bookTitle}</p>
 									<button id="delete-btn">삭제하기</button>
 								</div>
-								<p>저자</p>
-								<p>출판사/출판연도</p>
+								<p>{data.bookAuthor}</p>
+								<p>
+									{data.bookPublishYear === null
+										? '출판사 / 출판연도'
+										: `${data.bookPublishingHouse} / ${data.bookPublishYear}`}
+								</p>
 							</div>
 							<div className="prscr_detail_user_wrapper">
 								<div className="userInfo_wrapper">
@@ -41,7 +111,11 @@ const OneLinePrscrDetail = () => {
 										src="/icon/profile/basic_profile_img.svg"
 										id="user_img"
 									/>
-									<p>사용자 닉네임</p>
+									<p>
+										{data.clientNickname === null
+											? '사용자 닉네임'
+											: data.clientNickname}
+									</p>
 								</div>
 								<div className="prscr_detail_evaluation_wrapper">
 									<button className="prscr_detail_evaluation_btn">
@@ -59,11 +133,11 @@ const OneLinePrscrDetail = () => {
 							</div>
 							<div className="prscr_detail_content_wrapper">
 								<div className="prscr_detail_content_title_wrapper">
-									<p>처방제목</p>
+									<p>{data.title}</p>
 								</div>
 								<div className="prscr_detail_content_about_wrapper">
 									<p>처방사유</p>
-									<p>이 책을 읽은 이유는...</p>
+									<p id="prscr_detail_content">{data.description}</p>
 								</div>
 							</div>
 						</div>

--- a/src/pages/Prescription/OneLinePrscrDetail.jsx
+++ b/src/pages/Prescription/OneLinePrscrDetail.jsx
@@ -10,6 +10,67 @@ const OneLinePrscrDetail = () => {
 	return (
 		<>
 			<Header />
+			<div className="oneLine_prscr_detail_container">
+				<div className="oneLinePrscr_detail_up_wrapper">
+					<div className="oneLinePrscr_detail_content_container">
+						<div className="prscr_detail_left_wrapper">
+							<div className="prscr_detail_img_wrapper">
+								<img
+									src="/loading_thumbnail_x4.png"
+									id="oneLine-prscr-book-img"
+								/>
+							</div>
+							<div className="prscr_detail_bookAbout_wrapper">
+								<p>책 정보</p>
+								<div className="bookAbout_content"></div>
+								<div className="bookKeyword_wrapper"></div>
+							</div>
+						</div>
+						<div className="prscr_detail_right_wrapper">
+							<div className="prscr_detail_bookInfo_wrapper">
+								<div className="bookInfo_title_wrapper">
+									<p>책 제목</p>
+									<button id="delete-btn">삭제하기</button>
+								</div>
+								<p>저자</p>
+								<p>출판사/출판연도</p>
+							</div>
+							<div className="prscr_detail_user_wrapper">
+								<div className="userInfo_wrapper">
+									<img
+										src="/icon/profile/basic_profile_img.svg"
+										id="user_img"
+									/>
+									<p>사용자 닉네임</p>
+								</div>
+								<div className="prscr_detail_evaluation_wrapper">
+									<button className="prscr_detail_evaluation_btn">
+										<img src="/icon/oneLine-prscr/like.png" id="like-icon" />
+										<span>좋은 추천이에요</span>
+									</button>
+									<button className="prscr_detail_evaluation_btn">
+										<img
+											src="/icon/oneLine-prscr/laughing.png"
+											id="laugh-icon"
+										/>
+										<span>도움이 되었어요</span>
+									</button>
+								</div>
+							</div>
+							<div className="prscr_detail_content_wrapper">
+								<div className="prscr_detail_content_title_wrapper">
+									<p>처방제목</p>
+								</div>
+								<div className="prscr_detail_content_about_wrapper">
+									<p>처방사유</p>
+									<p>이 책을 읽은 이유는...</p>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div className="oneLinePrscr_detail_down_wrapper"></div>
+			</div>
 		</>
 	);
 };

--- a/src/styles/HashTag.css
+++ b/src/styles/HashTag.css
@@ -68,5 +68,5 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	padding: 15px;
+	/* padding: 15px; */
 }

--- a/src/styles/Prescription/OneLinePrscrDetail.css
+++ b/src/styles/Prescription/OneLinePrscrDetail.css
@@ -41,6 +41,7 @@
 #oneLine-prscr-book-img {
 	width: 250px;
 	height: 100%;
+	box-shadow: 2px 2px 8px 4px rgba(0, 0, 0, 0.25);
 }
 
 .prscr_detail_bookAbout_wrapper {
@@ -61,7 +62,15 @@
 	width: 100%;
 	height: 250px;
 	margin-top: 15px;
-	background-color: blue;
+	/* background-color: blue; */
+	font-family: var(--basic-font);
+	font-size: 16px;
+	line-height: 25px;
+	font-weight: 400;
+	color: #000;
+	overflow-y: scroll;
+	text-overflow: ellipsis;
+	scrollbar-width: thin;
 }
 
 .bookKeyword_wrapper {
@@ -69,7 +78,7 @@
 	width: 100%;
 	height: 70px;
 	margin-top: 20px;
-	background-color: red;
+	/* background-color: red; */
 }
 
 .prscr_detail_right_wrapper {
@@ -92,7 +101,7 @@
 	height: 65px;
 	justify-content: space-between;
 	align-items: flex-start;
-	padding-right: 60px;
+	/* padding-right: 60px; */
 	font-size: 28px;
 	font-family: var(--basic-font);
 	font-weight: 600;
@@ -149,7 +158,7 @@
 	width: 310px;
 	align-items: center;
 	justify-content: space-between;
-	margin-right: 60px;
+	/* margin-right: 60px; */
 }
 
 .prscr_detail_evaluation_btn {
@@ -199,4 +208,21 @@
 	font-weight: 600;
 	color: #454545;
 	border-bottom: 1px solid #d9d9d9;
+}
+
+.prscr_detail_content_about_wrapper > p {
+	font-family: var(--basic-font);
+	font-size: 18px;
+	font-weight: 600;
+	color: #454545;
+	margin-bottom: 15px;
+}
+
+#prscr_detail_content {
+	font-family: var(--basic-font);
+	font-size: 16px;
+	line-height: 19px;
+	font-weight: 400;
+	color: #000;
+	/* margin-bottom: 15px; */
 }

--- a/src/styles/Prescription/OneLinePrscrDetail.css
+++ b/src/styles/Prescription/OneLinePrscrDetail.css
@@ -1,0 +1,202 @@
+.oneLine_prscr_detail_container {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+}
+
+.oneLinePrscr_detail_up_wrapper {
+	display: flex;
+	justify-content: center;
+	width: 100%;
+	height: 265px;
+	background-color: #f7fbff;
+	box-shadow: 2px 2px 4px 0 rgba(0, 0, 0, 0.25);
+}
+
+.oneLinePrscr_detail_content_container {
+	display: flex;
+	justify-content: center;
+	width: 100%;
+	height: fit-content;
+	max-width: 1080px;
+	z-index: 1;
+	padding: 50px 0;
+	/* background-color: yellow; */
+}
+
+.prscr_detail_left_wrapper {
+	display: flex;
+	flex-direction: column;
+	/* align-items: center; */
+	width: 35%;
+	height: 100%;
+}
+
+.prscr_detail_img_wrapper {
+	text-align: center;
+	height: 60%;
+	margin-bottom: 40px;
+}
+
+#oneLine-prscr-book-img {
+	width: 250px;
+	height: 100%;
+}
+
+.prscr_detail_bookAbout_wrapper {
+	padding-left: 25px;
+}
+
+.prscr_detail_bookAbout_wrapper > p {
+	/* margin-left: 25px; */
+	font-family: var(--basic-font);
+	font-size: 32px;
+	font-weight: 600;
+	font-style: normal;
+	line-height: 36px;
+}
+
+.bookAbout_content {
+	display: flex;
+	width: 100%;
+	height: 250px;
+	margin-top: 15px;
+	background-color: blue;
+}
+
+.bookKeyword_wrapper {
+	display: flex;
+	width: 100%;
+	height: 70px;
+	margin-top: 20px;
+	background-color: red;
+}
+
+.prscr_detail_right_wrapper {
+	display: flex;
+	flex-direction: column;
+	width: 65%;
+	margin-left: 40px;
+}
+
+.prscr_detail_bookInfo_wrapper {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	height: 215px;
+}
+
+.bookInfo_title_wrapper {
+	display: flex;
+	width: 100%;
+	height: 65px;
+	justify-content: space-between;
+	align-items: flex-start;
+	padding-right: 60px;
+	font-size: 28px;
+	font-family: var(--basic-font);
+	font-weight: 600;
+}
+
+.prscr_detail_bookInfo_wrapper > p {
+	margin-bottom: 5px;
+	font-size: 20px;
+	line-height: 24px;
+	font-weight: 600;
+	font-style: normal;
+	font-family: var(--basic-font);
+	color: #454545;
+}
+
+#delete-btn {
+	width: 100px;
+	height: 40px;
+	background-color: #ffdadf;
+	border-radius: 10px;
+	font-size: 16px;
+	text-align: center;
+	font-weight: 600;
+}
+
+.prscr_detail_user_wrapper {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	width: 100%;
+	height: 45px;
+	margin: 25px 0;
+}
+
+.userInfo_wrapper {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	font-size: 14px;
+	font-weight: 600;
+	font-family: var(--basic-font);
+	font-style: normal;
+}
+
+.userInfo_wrapper > #user_img {
+	width: 40px;
+	height: 40px;
+	margin-right: 10px;
+}
+
+.prscr_detail_evaluation_wrapper {
+	display: flex;
+	width: 310px;
+	align-items: center;
+	justify-content: space-between;
+	margin-right: 60px;
+}
+
+.prscr_detail_evaluation_btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 150px;
+	height: 45px;
+	margin-right: 10px;
+	padding-top: 5px;
+	font-size: 14px;
+	font-weight: 600;
+	font-family: var(--basic-font);
+	font-style: normal;
+	line-height: 19px;
+
+	background-color: #fff;
+	border-radius: 15px;
+	border: 2px solid #d9d9d9;
+}
+
+.prscr_detail_evaluation_btn > #laugh-icon,
+.prscr_detail_evaluation_btn > #like-icon {
+	width: 20px;
+	height: 20px;
+	margin-right: 5px;
+}
+
+.prscr_detail_content_wrapper {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	height: 380px;
+	border-radius: 30px;
+	padding: 25px;
+	box-shadow: 2px 2px 12px -2px rgba(0, 0, 0, 0.25);
+}
+
+.prscr_detail_content_title_wrapper {
+	display: flex;
+	align-items: center;
+	margin-bottom: 20px;
+	width: 100%;
+	height: 40px;
+	font-family: var(--basic-font);
+	font-size: 20px;
+	font-weight: 600;
+	color: #454545;
+	border-bottom: 1px solid #d9d9d9;
+}


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 feature/oneLine-prscrDetail
- #194
- #195 

### ✅ 작업한 내용
- 한 줄 처방 목록에서 처방전 카드 클릭 시 페이지 이동 구현
- 한 줄 처방전 상세 보기 페이지 UI 구현
- 책 키워드 해시태그 스타일 수정
- 한 줄 처방전 상세 보기 페이지 API 연결

### ❗️PR Point
- 좋아요 기능에 대한 API 개발 후 연결 필요
- 본인의 처방전일 경우에만 삭제버튼 활성화되도록 수정 필요함

### 📸 스크린샷
![image](https://github.com/kw-bookmedicine/frontend/assets/46856766/eedc1f7f-4ba9-4999-9026-3ca51a47e1b0)
