### PR TITLE
🐛 Fix: 고민 상담 페이지 에러 수정

### DIFF
--- a/src/pages/Prescription/Counseling.jsx
+++ b/src/pages/Prescription/Counseling.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
 
@@ -16,11 +16,11 @@ const Counseling = () => {
 	const [page, setPage] = useState(0);
 	const [isLoading, setIsLoading] = useState(false);
 	const [testArr, setTestArr] = useState([]);
+	const pageEnd = useRef();
 
 	const [iconUrl, setIconUrl] = useState('/icon/white_search_icon.svg');
 	const [iconClick, setIconClick] = useState(false);
 
-	const [clickCtg, setClickCtg] = useState('');
 	const [keyword, setKeyword] = useState('');
 
 	const [category, setCategory] = useState([]);
@@ -30,19 +30,6 @@ const Counseling = () => {
 			setIconUrl('/icon/black_search_icon.svg');
 		} else {
 			setIconUrl('/icon/white_search_icon.svg');
-		}
-	};
-
-	const getData = () => {
-		try {
-			api.get(`/api/board/all?size=20&page=0`).then((res) => {
-				if (res.data.end) {
-					console.log('데이터 없음');
-				}
-				setTestArr(res.data);
-			});
-		} catch (err) {
-			console.log(err);
 		}
 	};
 
@@ -57,7 +44,6 @@ const Counseling = () => {
 	};
 
 	useEffect(() => {
-		getData();
 		getCategory();
 	}, []);
 
@@ -67,12 +53,13 @@ const Counseling = () => {
 	}, [page]);
 
 	// 타겟을 만날 때마다 API 호출
-	const fetchData = async () => {
+	const fetchData = () => {
+		// console.log('fetchData: ', page);
 		// 로딩 시작
 		setIsLoading(true);
 
 		try {
-			api.get(`/api/board/all?size=20&page=${page + 1}`).then((res) => {
+			api.get(`/api/board/all?size=5&page=${page}`).then((res) => {
 				if (res.data.end) {
 					console.log('데이터 없음');
 				}
@@ -89,22 +76,40 @@ const Counseling = () => {
 	useEffect(() => {
 		const handleObserver = (entries) => {
 			const target = entries[0];
-			// if (target.isIntersecting) {
-			// 	console.log(entries);
-			// }
 			if (target.isIntersecting && !isLoading) {
+				// console.log('visible');
 				setPage((prevPage) => prevPage + 1);
 			}
 		};
 
+		// 로딩되었을 때만 실행
 		const observer = new IntersectionObserver(handleObserver, {
 			threshold: 0.5,
 		});
 
-		const target = document.getElementById('cn_target');
-		if (target) {
-			observer.observe(target);
-		}
+		// 탐색 시작
+		// const target = document.getElementById('cn_target');
+		// if (target) {
+
+		// }
+		observer.observe(pageEnd.current);
+		// if (props.isLoading) {
+
+		// }
+
+		// const target = entries[0];
+		// if (target.isIntersecting && !isLoading) {
+		// 	setPage(page + 1);
+		// }
+
+		// const observer = new IntersectionObserver(handleObserver, {
+		// 	threshold: 0.5,
+		// });
+
+		// const target = document.getElementById('cn_target');
+		// if (target) {
+		// 	observer.observe(target);
+		// }
 	}, []);
 
 	const handleIcon = (e) => {
@@ -309,17 +314,14 @@ const Counseling = () => {
 							</Link>
 						</div>
 					</div>
-
-					{testArr.map((item, idx) => {
-						return (
-							<div className="cnsFeed_card_wrapper" key={item.boardId}>
-								<CnsFeed key={item.boardId + idx} item={item} />
-							</div>
-						);
-					})}
+					<div className="cnsFeed_card_wrapper">
+						{testArr.map((item, idx) => {
+							return <CnsFeed key={`${idx}-${item.boardId}`} item={item} />;
+						})}
+					</div>
 				</div>
 				{isLoading && <p>Loading...</p>}
-				<div id="cn_target"></div>
+				<div id="cn_target" ref={pageEnd}></div>
 			</div>
 		</>
 	);

--- a/src/pages/Prescription/Counseling.jsx
+++ b/src/pages/Prescription/Counseling.jsx
@@ -21,10 +21,15 @@ const Counseling = () => {
 	const [iconUrl, setIconUrl] = useState('/icon/white_search_icon.svg');
 	const [iconClick, setIconClick] = useState(false);
 
-	const [keyword, setKeyword] = useState('');
+	const [keyword, setKeyword] = useState('All'); // 지금 선택된 카테고리 여부
+	const [isClick, setIsClick] = useState(false); // 카테고리 선택 여부
+	const [prevClick, setPrevClick] = useState(''); // 이전에 클릭한 아이콘
+	const [keywordArr, setKeywordArr] = useState([]); // 카테고리별 피드 데이터 읽어서 넣기
+	const [keywordPage, setKeywordPage] = useState(0); // 카테고리 불러올 페이지
 
-	const [category, setCategory] = useState([]);
+	const [category, setCategory] = useState([]); // 처음으로 가져오는 카테고리
 
+	// 검색창에 이용
 	const handleIconUrl = async () => {
 		if (!iconClick) {
 			setIconUrl('/icon/black_search_icon.svg');
@@ -33,6 +38,7 @@ const Counseling = () => {
 		}
 	};
 
+	// 카테고리 가져오기
 	const getCategory = () => {
 		try {
 			api.get(`/api/boardKeyword/keyword`).then((res) => {
@@ -43,26 +49,21 @@ const Counseling = () => {
 		}
 	};
 
+	// 첫 렌더링될 때 카테고리 가져옴
 	useEffect(() => {
 		getCategory();
 	}, []);
 
-	// page 변경 감지에 따른 API호출
-	useEffect(() => {
-		fetchData();
-	}, [page]);
-
 	// 타겟을 만날 때마다 API 호출
 	const fetchData = () => {
-		// console.log('fetchData: ', page);
-		// 로딩 시작
-		setIsLoading(true);
+		setIsLoading(true); // 로딩 시작
 
 		try {
 			api.get(`/api/board/all?size=5&page=${page}`).then((res) => {
 				if (res.data.end) {
 					console.log('데이터 없음');
 				}
+				// console.log(res.data);
 				setTestArr((prevData) => [...prevData, ...res.data]);
 			});
 		} catch (error) {
@@ -73,6 +74,8 @@ const Counseling = () => {
 		}
 	};
 
+	// 하단 타겟 인식해서 page 늘려줌
+	// 카테고리 설정된 상태에서 인식되면 카테고리 페이지를 늘려줘야 함.
 	useEffect(() => {
 		const handleObserver = (entries) => {
 			const target = entries[0];
@@ -87,61 +90,59 @@ const Counseling = () => {
 			threshold: 0.5,
 		});
 
-		// 탐색 시작
-		// const target = document.getElementById('cn_target');
-		// if (target) {
-
-		// }
 		observer.observe(pageEnd.current);
-		// if (props.isLoading) {
-
-		// }
-
-		// const target = entries[0];
-		// if (target.isIntersecting && !isLoading) {
-		// 	setPage(page + 1);
-		// }
-
-		// const observer = new IntersectionObserver(handleObserver, {
-		// 	threshold: 0.5,
-		// });
-
-		// const target = document.getElementById('cn_target');
-		// if (target) {
-		// 	observer.observe(target);
-		// }
 	}, []);
 
+	// 아이콘 클릭 여부 핸들링 함수
 	const handleIcon = (e) => {
-		// 모든 아이콘 글씨 색 초기화
-		const icons = document.querySelectorAll('.cns_category_text');
-		icons.forEach((icon) => {
-			if (icon.className === 'cns_category_text') {
-				icon.style.color = 'black';
-				icon.style.fontWeight = '400';
-			} else {
-				icon.style.color = 'black';
-				icon.style.fontWeight = '400';
-			}
-		});
+		const targetCtg = e.target.id;
+		const target = document.getElementById(`${targetCtg}`);
+		const prevTarget = document.getElementById(`${prevClick}`);
+		const targetText = target.querySelector('.cns_category_text');
 
-		// 클릭된 아이콘만 색상 설정
-		const clickedIcon = e.currentTarget.querySelector('.cns_category_text');
-		ctgType(clickedIcon.innerText);
-		// console.log(clickedIcon.innerText);
-		clickedIcon.style.color = 'red';
-		clickedIcon.style.fontWeight = '600';
-		clickedIcon.classList.toggle('icon-active');
+		if (keyword === 'All') {
+			if (prevClick !== '') {
+				// console.log('중복');
+				// 동일한 아이콘 2번 눌렀다가 다시 눌렀을 때, 중복처리 되는 거 방지하기 위함.
+				setPrevClick(e.target.id);
+				fetchData();
+			}
+		} else {
+			setPrevClick(e.target.id);
+		}
+
+		// 제일 처음 클릭된 거를 이전 클릭으로 지정
+		if (prevClick === '') {
+			setPrevClick(e.target.id);
+		}
+
+		if (prevClick !== '' && prevClick !== e.target.id && keyword !== 'All') {
+			if (prevTarget !== null) {
+				// 먼저 클릭된 아이콘이 있을 때
+				const prevTargetText = prevTarget.querySelector('.cns_category_text');
+				prevTargetText.classList.remove('icon-active');
+			}
+		}
+
+		if (targetText.className === 'cns_category_text') {
+			// 아이콘이 클릭되었을 때
+			targetText.classList.toggle('icon-active');
+			ctgType(targetText.innerText);
+		} else {
+			// 클릭된 아이콘을 다시 클릭했을 때
+			targetText.classList.toggle('icon-active');
+			setPrevClick(e.target.id);
+			ctgType('전체');
+		}
 	};
 
 	// 선택된 키워드 타입 지정
 	const ctgType = async (ctg) => {
-		console.log('category:' + ctg);
 		switch (ctg) {
 			case '관계/소통':
 				setKeyword('Relationships_Communication');
 				break;
-			case '소셜/에세이':
+			case '소설/에세이':
 				setKeyword('Fiction_Essays');
 				break;
 			case '경제/경영':
@@ -177,29 +178,57 @@ const Counseling = () => {
 			case '기타':
 				setKeyword('ETC');
 				break;
+			case '전체':
+				setKeyword('All');
+				break;
 		}
 	};
 
+	// 키워드가 바뀔 때마다 API 호출
 	useEffect(() => {
-		fetchKeyword();
+		setPage(0);
+		setKeywordPage(0);
+		setTestArr([]);
+		setKeywordArr([]);
+		if (keyword !== 'All') {
+			// window.location.reload();
+			fetchKeyword();
+		}
 	}, [keyword]);
+
+	// page 변경 감지에 따른 API호출
+	useEffect(() => {
+		if (keyword === 'All') {
+			fetchData();
+		}
+	}, [page]);
+
+	// useEffect(() => {
+	// 	if (keyword !== 'All') {
+	// 		fetchKeyword();
+	// 	}
+	// },[keywordPage])
 
 	// 키워드별 검색
 	const fetchKeyword = async () => {
 		try {
 			if (keyword !== '') {
 				api
-					.get(`api/board/keyword?keyword=${keyword}&page=0&size=20`)
+					.get(
+						`api/board/keyword?keyword=${keyword}&page=${keywordPage}&size=5`,
+					)
 					.then((res) => {
 						if (res.data.length === 0) {
 							alert('조회된 게시글이 없습니다.');
+							setKeyword('All');
 							// 페이지 새로고침
 							window.location.reload();
 						}
 						if (res.data.end) {
 							console.log('데이터 없음.');
 						}
-						setTestArr(res.data);
+						console.log(res.data);
+						setKeywordArr((prevData) => [...prevData, ...res.data]);
 					});
 			}
 		} catch (err) {
@@ -255,8 +284,11 @@ const Counseling = () => {
 										src={`icon/prscr-category/${changeItem}-icon.svg`}
 										alt={item}
 										className="cns_category_img"
+										id={item}
 									/>
-									<span className="cns_category_text">{item}</span>
+									<span className="cns_category_text" id={item}>
+										{item}
+									</span>
 								</div>
 							);
 						})}
@@ -315,9 +347,16 @@ const Counseling = () => {
 						</div>
 					</div>
 					<div className="cnsFeed_card_wrapper">
-						{testArr.map((item, idx) => {
-							return <CnsFeed key={`${idx}-${item.boardId}`} item={item} />;
-						})}
+						{}
+						{keywordArr.length > 0
+							? keywordArr.map((item, idx) => {
+									return (
+										<CnsFeed key={`keywordFeed-${idx}-${item}`} item={item} />
+									);
+							  })
+							: testArr.map((item, idx) => {
+									return <CnsFeed key={`${idx}-${item.boardId}`} item={item} />;
+							  })}
 					</div>
 				</div>
 				{isLoading && <p>Loading...</p>}

--- a/src/styles/Counseling/Counseling.css
+++ b/src/styles/Counseling/Counseling.css
@@ -44,6 +44,16 @@
 	cursor: pointer;
 }
 
+.cns_category_text {
+	margin-top: 14px;
+	font-family: var(--basic-font);
+	font-style: normal;
+	font-size: 14px;
+	font-weight: 400;
+	line-height: 19px;
+	color: #000;
+}
+
 .icon-active {
 	font-weight: 800;
 	color: red;
@@ -58,14 +68,6 @@
 
 .cns_category_img:hover {
 	transform: scale(1.3, 1.3);
-}
-
-.cns_category_text {
-	margin-top: 14px;
-	font-family: var(--basic-font);
-	font-size: 14px;
-	font-style: normal;
-	line-height: 19px;
 }
 
 .counseling_feed_wrapper {

--- a/src/styles/Counseling/Counseling.css
+++ b/src/styles/Counseling/Counseling.css
@@ -176,13 +176,12 @@
 
 .cnsFeed_card_wrapper {
 	width: 100%;
-	height: 200px;
+	height: fit-content;
 	display: flex;
+	flex-direction: column;
 	justify-content: center;
+	align-items: center;
 	margin: 20px 0;
-	/* transition: all 0.5s ease-in-out; */
-	/* transform: scale(1.5); */
-	opacity: 1;
 }
 
 .cnsFeed_card_wrapper .visible {


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 feature/prscr-write

### ✅ 작업한 내용
- 무한스크롤 제일 하단 타겟 인식 안 되는 문제 해결
- 이미 선택된 카테고리 선택 시 전체 조회할 수 있도록 변경

### ❗️PR Point
- 전체 고민글에 대한 array랑 키워드별 array를 따로 호출하고 있는데, 이를 하나의 array로 해서 렌더링할 수 있는 방법있으면 리팩토링 진행해보기

### 📸 스크린샷
- `관계/소통` 이라는 키워드로 고민 글을 조회한 경우
![image](https://github.com/kw-bookmedicine/frontend/assets/46856766/872f4c11-94c7-469c-83fd-8d1c4c090fa6)



- 카테고리 버튼을 한 번 더 눌렀을 때, 전체 고민 글이 조회되는 모습
![image](https://github.com/kw-bookmedicine/frontend/assets/46856766/ff59b236-b9b9-49cd-8183-c26c6bb010fc)

