### PR TITLE
:sparkles: Feat: 처방전 작성 글자수 제한 표시

### DIFF
--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,0 +1,3 @@
+export const MAX_LENGTH_DESCRIPTION = 1000;
+export const MAX_LENGTH_DEFAULT = 255;
+export const MAX_LENGTH_TITLE = 100;

--- a/src/pages/Prescription/PrescriptionWrite.jsx
+++ b/src/pages/Prescription/PrescriptionWrite.jsx
@@ -16,6 +16,11 @@ import api from "../../services/api";
 
 // STYLE
 import "../../styles/Counseling/PrescriptionWrite.css";
+import {
+  MAX_LENGTH_DEFAULT,
+  MAX_LENGTH_DESCRIPTION,
+  MAX_LENGTH_TITLE,
+} from "../../constants/constants";
 
 // todo
 // -focus가 되어있을때, 처방전 작성하기 버튼을 누르면 조금 스크롤 이동이 되는 버그 발생-> css 없애면 잘 작동함..
@@ -91,7 +96,7 @@ const PrescriptionWrite = () => {
     observer.observe(box);
   });
 
-  const { register, handleSubmit, setValue } = useForm({
+  const { register, handleSubmit, setValue, watch } = useForm({
     defaultValues: {
       title: location.state?.title || "",
       description: location.state?.description || "",
@@ -100,6 +105,9 @@ const PrescriptionWrite = () => {
       prescriptionId: location.state?.prescriptionId || undefined,
     },
   });
+
+  const title = watch("title");
+  const description = watch("description");
 
   const postPrscr = async (data) => {
     try {
@@ -277,19 +285,34 @@ const PrescriptionWrite = () => {
           >
             <div id="prscr_write_box">
               <label>
-                <p>제목</p>
+                <p className="prescription_content_bottom_text">
+                  제목{" "}
+                  <span>
+                    [ {title.length} / {MAX_LENGTH_TITLE}자 ]
+                  </span>
+                </p>
                 <input
                   {...register("title", { required: true })}
                   type="text"
                   placeholder="처방 제목을 작성하세요"
+                  maxLength={MAX_LENGTH_TITLE}
+                  minLength={1}
                 />
               </label>
               <label>
-                <p>처방사유</p>
+                <p className="prescription_content_bottom_text">
+                  처방사유{" "}
+                  <span>
+                    [ {description.length} / {MAX_LENGTH_DESCRIPTION}자 ]
+                  </span>
+                </p>
+
                 <textarea
                   {...register("description", { required: true })}
                   type="text"
                   placeholder="처방사유를 작성하세요"
+                  maxLength={MAX_LENGTH_DESCRIPTION}
+                  minLength={1}
                 />
               </label>
             </div>

--- a/src/styles/Counseling/PrescriptionWrite.css
+++ b/src/styles/Counseling/PrescriptionWrite.css
@@ -152,6 +152,14 @@ button {
   height: 50vh;
 }
 
+.prescription_content_bottom_text {
+  color: black;
+}
+
+.prescription_content_bottom_text span {
+  color: #c2c2c2;
+}
+
 .prescription_btn_container {
   display: flex;
   align-items: center;


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #231 

### ✅ 작업한 내용
- 작성할 때, 글자수 제한 표시하도록 구현

### ❗️PR Point
- 입력이 많을 시, 처방사유에서 넘치도록 보임
![image](https://github.com/kw-bookmedicine/frontend/assets/96184691/625a1b8b-35d0-4b38-b857-e3cbe2eab2bd)
![image](https://github.com/kw-bookmedicine/frontend/assets/96184691/b99676ae-8fde-4567-83d1-861be7988cda)


### 📸 스크린샷
![image](https://github.com/kw-bookmedicine/frontend/assets/96184691/ba823a79-07d5-48c9-9ef3-736127d0f650)

closed #231 
