### PR TITLE
✨ Feat: 본인 글인 경우에만 수정, 삭제 버튼 보이기

### DIFF
--- a/src/pages/Prescription/OneLinePrscrDetail.jsx
+++ b/src/pages/Prescription/OneLinePrscrDetail.jsx
@@ -8,6 +8,7 @@ import ConfirmModal from '../../components/Modal/ConfirmModal';
 
 // SERVICE
 import api from '../../services/api';
+import useNicknameStore from '../../store/nickname-store';
 
 // STYLE
 import '../../styles/Prescription/OneLinePrscrDetail.css';
@@ -22,7 +23,14 @@ const OneLinePrscrDetail = () => {
 	const [bookData, setBookData] = useState({});
 	const [keywordArr, setKeywordArr] = useState([]);
 
-	const fetchData = () => {
+	const { nickname } = useNicknameStore();
+	const [fetchNickname, setFetchNickname] = useState(
+		sessionStorage.getItem('nickname') || '',
+	);
+	const [writer, setWriter] = useState(sessionStorage.getItem('writer') || '');
+	const [isShow, setIsShow] = useState(false);
+
+	const fetchData = async () => {
 		try {
 			api
 				.get(`/api/oneline-prescriptions/${prscrId}`, {
@@ -30,6 +38,8 @@ const OneLinePrscrDetail = () => {
 				})
 				.then((res) => {
 					setData(res.data);
+					setWriter(res.data.clientNickname);
+					sessionStorage.setItem('writer', res.data.clientNickname);
 				});
 		} catch (err) {
 			console.log(err);
@@ -55,24 +65,36 @@ const OneLinePrscrDetail = () => {
 		}
 	};
 
+	const showBtnHandler = async () => {
+		if (writer !== '') {
+			if (writer !== fetchNickname) {
+				setIsShow(false);
+			} else {
+				setIsShow(true);
+			}
+		} else {
+			console.log('유저 닉네임 정보가 없습니다.');
+		}
+	};
+
 	useEffect(() => {
 		fetchData();
 		getBookData();
+		setFetchNickname(nickname);
+		if (nickname !== '') {
+			sessionStorage.setItem('nickname', nickname);
+		}
+	}, []);
+
+	useEffect(() => {
+		showBtnHandler();
 	}, []);
 
 	const editPrscr = () => {
 		navigate(
 			`/oneline/prescription/edit?prscrId=${prscrId}&bookIsbn=${bookIsbn}`,
 		);
-		// try {
-		// 	api.put(`/api/oneline-prescriptions/${prscrId}`).then((res) => {
-		// 		console.log(res.data);
-		// 		// window.location.replace('/oneline/prescription/write');
-		// 	});
-		// } catch (err) {
-		// 	console.log(err);
-		// }
-		console.log('수정');
+		// console.log('수정');
 	};
 
 	const deletePrscr = () => {
@@ -138,12 +160,16 @@ const OneLinePrscrDetail = () => {
 								<div className="bookInfo_title_wrapper">
 									<p>{data.bookTitle}</p>
 									<div className="bookInfo_title_btn_wrapper">
-										<button id="edit-btn" onClick={editPrscr}>
-											수정하기
-										</button>
-										<button id="delete-btn" onClick={deletePrscr}>
-											삭제하기
-										</button>
+										{isShow && (
+											<>
+												<button id="edit-btn" onClick={editPrscr}>
+													수정하기
+												</button>
+												<button id="delete-btn" onClick={deletePrscr}>
+													삭제하기
+												</button>
+											</>
+										)}
 									</div>
 								</div>
 								<p>{data.bookAuthor}</p>


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 feature/oneLine-prscrDetail
- #244 

### ✅ 작업한 내용
- 본인이 작성한 한 줄 처방 글인 경우에만 수정, 삭제 버튼 보이기

### ❗️PR Point
- useNicknameStore() 훅으로 가져온 유저 닉네임 정보가 페이지 새로고침하게 되면 사라짐.
- sesseionStorage로 유저 정보 저장하는 방법으로 구현함.
- 추후 해당 훅으로 가져온 정보가 새로고침해도 사라지지 않는 방법에 대해 찾아볼 필요 있음.

### 📸 스크린샷
##### 유저 이름이 다른 경우
![image](https://github.com/kw-bookmedicine/frontend/assets/46856766/57f37cfb-7e2e-4b83-bfcd-3794c757e76e)


##### 유저 이름이 같은 경우
![image](https://github.com/kw-bookmedicine/frontend/assets/46856766/bb9c41d9-aa75-4f4e-9516-241a1034d037)


closed #이슈번호
