### PR TITLE
:bug: Fix: 소설/에세이 오타로 ETC 요청 버그 수정

### DIFF
--- a/src/pages/Worry/WorryWrite.jsx
+++ b/src/pages/Worry/WorryWrite.jsx
@@ -106,7 +106,7 @@ const apiEndpointMap = {
   취업: "Employment_Career",
   "문제집/수험서": "Workbook_Examination",
   "관계/소통": "Relationships_Communication",
-  "소셜/에세이": "Fiction_Essays",
+  "소설/에세이": "Fiction_Essays",
   철학: "Philosophy",
   역사: "History",
   "수학/과학/공학": "Science_Math_Engineering",


### PR DESCRIPTION
# 🔥 Pull requests
### 🌴 작업한 브랜치
- #346 

### ✅ 작업한 내용
- '소셜/에세이' 라고 오타로 인하여 ETC로 요청이 되어서 '소설/에세이' 오타 수정하였습니다.

### ❗️PR Point

### 📸 스크린샷


closed #346 
